### PR TITLE
Use hardware intrinsics for CRC32C when available

### DIFF
--- a/Snappier.Benchmarks/Crc32CAlgorithm.cs
+++ b/Snappier.Benchmarks/Crc32CAlgorithm.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace Snappier.Benchmarks
+{
+    [SimpleJob(RuntimeMoniker.NetCoreApp21, baseline: true)]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
+    public class Crc32CAlgorithm
+    {
+        private byte[] _buffer;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _buffer = new byte[65536];
+            new Random().NextBytes(_buffer);
+        }
+
+        [Benchmark]
+        public uint Default()
+        {
+            return Internal.Crc32CAlgorithm.Append(0, _buffer);
+        }
+    }
+}

--- a/Snappier.Tests/Internal/Crc32CAlgorithmTests.cs
+++ b/Snappier.Tests/Internal/Crc32CAlgorithmTests.cs
@@ -10,16 +10,18 @@ namespace Snappier.Tests.Internal
     {
         [Theory]
         [InlineData("123456789", 0xe3069283)]
+        [InlineData("1234567890123456", 0x9aa4287f)]
+        [InlineData("123456789012345612345678901234", 0xecc74934)]
+        [InlineData("12345678901234561234567890123456", 0xcd486b4b)]
         public void Compute(string asciiChars, uint expectedResult)
         {
             // Arrange
 
-            var crc = new Crc32CAlgorithm();
             var bytes = Encoding.ASCII.GetBytes(asciiChars);
 
             // Act
 
-            var result = crc.ComputeHash(bytes);
+            var result = Crc32CAlgorithm.Compute(bytes);
 
             // Assert
 

--- a/Snappier/Internal/SnappyStreamCompressor.cs
+++ b/Snappier/Internal/SnappyStreamCompressor.cs
@@ -23,7 +23,6 @@ namespace Snappier.Internal
         };
 
         private SnappyCompressor? _compressor = new SnappyCompressor();
-        private readonly Crc32CAlgorithm _crc = new Crc32CAlgorithm();
 
         private IMemoryOwner<byte>? _inputBufferOwner;
         private Memory<byte> _inputBuffer;
@@ -283,7 +282,7 @@ namespace Snappier.Internal
             BinaryPrimitives.WriteInt32LittleEndian(output.Slice(1), blockSize);
             output[0] = (byte) Constants.ChunkType.CompressedData;
 
-            var crc = _crc.ComputeHash(input);
+            var crc = Crc32CAlgorithm.Compute(input);
             crc = Crc32CAlgorithm.ApplyMask(crc);
             BinaryPrimitives.WriteUInt32LittleEndian(output.Slice(4), crc);
         }


### PR DESCRIPTION
On modern Intel processors running on .NET Core 3.1 in 64-bit, this
is resulting in an approximately 6x faster CRC32C calculation compared
to .NET Core 2.1 against a 64KB buffer.

|  Method |       Runtime |      Mean |     Error |    StdDev | Ratio | Rank |
|-------- |-------------- |----------:|----------:|----------:|------:|-----:|
| Default | .NET Core 2.1 | 39.789 us | 0.6658 us | 0.9333 us |  1.00 |    2 |
| Default | .NET Core 3.1 |  6.017 us | 0.0502 us | 0.0469 us |  0.15 |    1 |