### PR TITLE
Fix PshufbFillPatterns once per call to DecompressAllTags

### DIFF
--- a/Snappier.Benchmarks/IncrementalCopy.cs
+++ b/Snappier.Benchmarks/IncrementalCopy.cs
@@ -13,7 +13,10 @@ namespace Snappier.Benchmarks
         {
             fixed (byte* buffer = _buffer)
             {
-                CopyHelpers.IncrementalCopy(buffer, buffer + 2, buffer + 18, buffer + _buffer.Length);
+                fixed (sbyte* pshufbFillPatterns = CopyHelpers.PshufbFillPatterns)
+                {
+                    CopyHelpers.IncrementalCopy(buffer, buffer + 2, buffer + 18, buffer + _buffer.Length, pshufbFillPatterns);
+                }
             }
         }
 

--- a/Snappier/Internal/SnappyDecompressor.cs
+++ b/Snappier/Internal/SnappyDecompressor.cs
@@ -149,136 +149,189 @@ namespace Snappier.Internal
                     {
                         fixed (byte* scratchStart = _scratch)
                         {
-                            var scratch = scratchStart;
-
-                            if (_scratchLength > 0)
+                            fixed (sbyte* pshufbFillPatterns = CopyHelpers.PshufbFillPatterns)
                             {
-                                // Have partial tag remaining from a previous decompress run
-                                // Get the combined tag in the scratch buffer, then run through
-                                // special case processing that gets the tag from the scratch buffer
-                                // and any literal data from the _input buffer
+                                var scratch = scratchStart;
 
-                                // scratch will be the scratch buffer with only the tag if true is returned
-                                if (!RefillTagFromScratch(ref input, inputEnd, scratch))
+                                if (_scratchLength > 0)
                                 {
-                                    return;
-                                }
+                                    // Have partial tag remaining from a previous decompress run
+                                    // Get the combined tag in the scratch buffer, then run through
+                                    // special case processing that gets the tag from the scratch buffer
+                                    // and any literal data from the _input buffer
 
-                                // No more scratch for next cycle, we have a full buffer we're about to use
-                                _scratchLength = 0;
-
-                                byte c = scratch[0];
-                                scratch++;
-
-                                if ((c & 0x03) == Constants.Literal)
-                                {
-                                    long literalLength = (c >> 2) + 1;
-                                    if (literalLength >= 61)
+                                    // scratch will be the scratch buffer with only the tag if true is returned
+                                    if (!RefillTagFromScratch(ref input, inputEnd, scratch))
                                     {
-                                        // Long literal.
-                                        long literalLengthLength = literalLength - 60;
-                                        var literalLengthTemp = Helpers.UnsafeReadInt32(scratch);
-
-                                        literalLength = (int) Helpers.ExtractLowBytes((uint) literalLengthTemp,
-                                            (int) literalLengthLength) + 1;
-                                    }
-
-                                    var inputRemaining = inputEnd - input;
-                                    if (inputRemaining < literalLength)
-                                    {
-                                        Append(buffer, input, inputRemaining);
-                                        _remainingLiteral = (int) (literalLength - inputRemaining);
-                                        _input = ReadOnlyMemory<byte>.Empty;
                                         return;
                                     }
+
+                                    // No more scratch for next cycle, we have a full buffer we're about to use
+                                    _scratchLength = 0;
+
+                                    byte c = scratch[0];
+                                    scratch++;
+
+                                    if ((c & 0x03) == Constants.Literal)
+                                    {
+                                        long literalLength = (c >> 2) + 1;
+                                        if (literalLength >= 61)
+                                        {
+                                            // Long literal.
+                                            long literalLengthLength = literalLength - 60;
+                                            var literalLengthTemp = Helpers.UnsafeReadInt32(scratch);
+
+                                            literalLength = (int) Helpers.ExtractLowBytes((uint) literalLengthTemp,
+                                                (int) literalLengthLength) + 1;
+                                        }
+
+                                        var inputRemaining = inputEnd - input;
+                                        if (inputRemaining < literalLength)
+                                        {
+                                            Append(buffer, input, inputRemaining);
+                                            _remainingLiteral = (int) (literalLength - inputRemaining);
+                                            _input = ReadOnlyMemory<byte>.Empty;
+                                            return;
+                                        }
+                                        else
+                                        {
+                                            Append(buffer, input, literalLength);
+                                            input += literalLength;
+                                        }
+                                    }
+                                    else if ((c & 3) == Constants.Copy4ByteOffset)
+                                    {
+                                        int copyOffset = Helpers.UnsafeReadInt32(scratch);
+
+                                        long length = (c >> 2) + 1;
+
+                                        AppendFromSelf(buffer, copyOffset, length, pshufbFillPatterns);
+                                    }
                                     else
                                     {
-                                        Append(buffer, input, literalLength);
-                                        input += literalLength;
-                                    }
-                                }
-                                else if ((c & 3) == Constants.Copy4ByteOffset)
-                                {
-                                    int copyOffset = Helpers.UnsafeReadInt32(scratch);
+                                        var entry = charTable[c];
+                                        int data = Helpers.UnsafeReadInt32(scratch);
 
-                                    long length = (c >> 2) + 1;
+                                        var trailer = (int) Helpers.ExtractLowBytes((uint) data, c & 3);
+                                        long length = entry & 0xff;
 
-                                    AppendFromSelf(buffer, copyOffset, length);
-                                }
-                                else
-                                {
-                                    var entry = charTable[c];
-                                    int data = Helpers.UnsafeReadInt32(scratch);
+                                        // copy_offset/256 is encoded in bits 8..10.  By just fetching
+                                        // those bits, we get copy_offset (since the bit-field starts at
+                                        // bit 8).
+                                        var copyOffset = (entry & 0x700) + trailer;
 
-                                    var trailer = (int) Helpers.ExtractLowBytes((uint) data, c & 3);
-                                    long length = entry & 0xff;
-
-                                    // copy_offset/256 is encoded in bits 8..10.  By just fetching
-                                    // those bits, we get copy_offset (since the bit-field starts at
-                                    // bit 8).
-                                    var copyOffset = (entry & 0x700) + trailer;
-
-                                    AppendFromSelf(buffer, copyOffset, length);
-                                }
-
-                                //  Make sure scratch is reset
-                                scratch = scratchStart;
-                            }
-
-                            if (input >= inputLimitMinMaxTagLength)
-                            {
-                                if (!RefillTag(ref input, ref inputEnd, scratch))
-                                {
-                                    goto exit;
-                                }
-                            }
-
-                            uint preload = Helpers.UnsafeReadUInt32(input);
-
-                            while (true)
-                            {
-                                var c = (byte) preload;
-                                input++;
-
-                                if ((c & 0x03) == Constants.Literal)
-                                {
-                                    long literalLength = (c >> 2) + 1;
-
-                                    if (TryFastAppend(buffer, input, inputEnd - input, literalLength))
-                                    {
-                                        Debug.Assert(literalLength < 61);
-                                        input += literalLength;
-                                        // NOTE: There is no RefillTag here, as TryFastAppend()
-                                        // will not return true unless there's already at least five spare
-                                        // bytes in addition to the literal.
-                                        preload = Helpers.UnsafeReadUInt32(input);
-                                        continue;
+                                        AppendFromSelf(buffer, copyOffset, length, pshufbFillPatterns);
                                     }
 
-                                    if (literalLength >= 61)
+                                    //  Make sure scratch is reset
+                                    scratch = scratchStart;
+                                }
+
+                                if (input >= inputLimitMinMaxTagLength)
+                                {
+                                    if (!RefillTag(ref input, ref inputEnd, scratch))
                                     {
-                                        // Long literal.
-                                        long literalLengthLength = literalLength - 60;
-                                        var literalLengthTemp = Helpers.UnsafeReadInt32(input);
-
-                                        literalLength = Helpers.ExtractLowBytes((uint) literalLengthTemp,
-                                            (int) literalLengthLength) + 1;
-
-                                        input += literalLengthLength;
-                                    }
-
-                                    var inputRemaining = inputEnd - input;
-                                    if (inputRemaining < literalLength)
-                                    {
-                                        Append(buffer, input, inputRemaining);
-                                        _remainingLiteral = (int) (literalLength - inputRemaining);
-                                        input = inputEnd;
                                         goto exit;
                                     }
+                                }
+
+                                uint preload = Helpers.UnsafeReadUInt32(input);
+
+                                while (true)
+                                {
+                                    var c = (byte) preload;
+                                    input++;
+
+                                    if ((c & 0x03) == Constants.Literal)
+                                    {
+                                        long literalLength = (c >> 2) + 1;
+
+                                        if (TryFastAppend(buffer, input, inputEnd - input, literalLength))
+                                        {
+                                            Debug.Assert(literalLength < 61);
+                                            input += literalLength;
+                                            // NOTE: There is no RefillTag here, as TryFastAppend()
+                                            // will not return true unless there's already at least five spare
+                                            // bytes in addition to the literal.
+                                            preload = Helpers.UnsafeReadUInt32(input);
+                                            continue;
+                                        }
+
+                                        if (literalLength >= 61)
+                                        {
+                                            // Long literal.
+                                            long literalLengthLength = literalLength - 60;
+                                            var literalLengthTemp = Helpers.UnsafeReadInt32(input);
+
+                                            literalLength = Helpers.ExtractLowBytes((uint) literalLengthTemp,
+                                                (int) literalLengthLength) + 1;
+
+                                            input += literalLengthLength;
+                                        }
+
+                                        var inputRemaining = inputEnd - input;
+                                        if (inputRemaining < literalLength)
+                                        {
+                                            Append(buffer, input, inputRemaining);
+                                            _remainingLiteral = (int) (literalLength - inputRemaining);
+                                            input = inputEnd;
+                                            goto exit;
+                                        }
+                                        else
+                                        {
+                                            Append(buffer, input, literalLength);
+                                            input += literalLength;
+
+                                            if (input >= inputLimitMinMaxTagLength)
+                                            {
+                                                if (!RefillTag(ref input, ref inputEnd, scratch))
+                                                {
+                                                    goto exit;
+                                                }
+
+                                                inputLimitMinMaxTagLength = inputEnd - Math.Min(inputEnd - input,
+                                                    Constants.MaximumTagLength - 1);
+                                            }
+
+                                            preload = Helpers.UnsafeReadUInt32(input);
+                                        }
+                                    }
                                     else
                                     {
-                                        Append(buffer, input, literalLength);
-                                        input += literalLength;
+                                        if ((c & 3) == Constants.Copy4ByteOffset)
+                                        {
+                                            int copyOffset = Helpers.UnsafeReadInt32(input);
+                                            input += 4;
+
+                                            var length = (c >> 2) + 1;
+                                            AppendFromSelf(buffer, copyOffset, length, pshufbFillPatterns);
+                                        }
+                                        else
+                                        {
+                                            var entry = charTable[c];
+
+                                            // We don't use BitConverter to read because we might be reading past the end of the span
+                                            // But we know that's safe because we'll be doing it in _scratch with extra data on the end.
+                                            // This reduces this step by several operations
+                                            preload = Helpers.UnsafeReadUInt32(input);
+
+                                            var trailer = (int) Helpers.ExtractLowBytes(preload, c & 3);
+                                            long length = entry & 0xff;
+
+                                            // copy_offset/256 is encoded in bits 8..10.  By just fetching
+                                            // those bits, we get copy_offset (since the bit-field starts at
+                                            // bit 8).
+                                            var copyOffset = (entry & 0x700) + trailer;
+
+                                            AppendFromSelf(buffer, copyOffset, length, pshufbFillPatterns);
+
+                                            input += c & 3;
+
+                                            // By using the result of the previous load we reduce the critical
+                                            // dependency chain of ip to 4 cycles.
+                                            preload >>= (c & 3) * 8;
+                                            if (input < inputLimitMinMaxTagLength) continue;
+                                        }
 
                                         if (input >= inputLimitMinMaxTagLength)
                                         {
@@ -294,62 +347,12 @@ namespace Snappier.Internal
                                         preload = Helpers.UnsafeReadUInt32(input);
                                     }
                                 }
-                                else
-                                {
-                                    if ((c & 3) == Constants.Copy4ByteOffset)
-                                    {
-                                        int copyOffset = Helpers.UnsafeReadInt32(input);
-                                        input += 4;
 
-                                        var length = (c >> 2) + 1;
-                                        AppendFromSelf(buffer, copyOffset, length);
-                                    }
-                                    else
-                                    {
-                                        var entry = charTable[c];
-
-                                        // We don't use BitConverter to read because we might be reading past the end of the span
-                                        // But we know that's safe because we'll be doing it in _scratch with extra data on the end.
-                                        // This reduces this step by several operations
-                                        preload = Helpers.UnsafeReadUInt32(input);
-
-                                        var trailer = (int) Helpers.ExtractLowBytes(preload, c & 3);
-                                        long length = entry & 0xff;
-
-                                        // copy_offset/256 is encoded in bits 8..10.  By just fetching
-                                        // those bits, we get copy_offset (since the bit-field starts at
-                                        // bit 8).
-                                        var copyOffset = (entry & 0x700) + trailer;
-
-                                        AppendFromSelf(buffer, copyOffset, length);
-
-                                        input += c & 3;
-
-                                        // By using the result of the previous load we reduce the critical
-                                        // dependency chain of ip to 4 cycles.
-                                        preload >>= (c & 3) * 8;
-                                        if (input < inputLimitMinMaxTagLength) continue;
-                                    }
-
-                                    if (input >= inputLimitMinMaxTagLength)
-                                    {
-                                        if (!RefillTag(ref input, ref inputEnd, scratch))
-                                        {
-                                            goto exit;
-                                        }
-
-                                        inputLimitMinMaxTagLength = inputEnd - Math.Min(inputEnd - input,
-                                            Constants.MaximumTagLength - 1);
-                                    }
-
-                                    preload = Helpers.UnsafeReadUInt32(input);
-                                }
+                                exit:
+                                _input = input < inputEnd
+                                    ? _input.Slice((int) (input - inputStart))
+                                    : ReadOnlyMemory<byte>.Empty;
                             }
-
-                            exit:
-                            _input = input < inputEnd
-                                ? _input.Slice((int) (input - inputStart))
-                                : ReadOnlyMemory<byte>.Empty;
                         }
                     }
                 }
@@ -517,13 +520,13 @@ namespace Snappier.Internal
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void AppendFromSelf(byte* buffer, int copyOffset, long length)
+        public unsafe void AppendFromSelf(byte* buffer, int copyOffset, long length, sbyte* pshufbFillPatterns)
         {
             Debug.Assert(copyOffset > 0);
             Debug.Assert(copyOffset <= _lookbackPosition);
 
             var op = buffer + _lookbackPosition;
-            CopyHelpers.IncrementalCopy(op - copyOffset, op, op + length, buffer + _lookbackBuffer.Length);
+            CopyHelpers.IncrementalCopy(op - copyOffset, op, op + length, buffer + _lookbackBuffer.Length, pshufbFillPatterns);
 
             _lookbackPosition += length;
         }


### PR DESCRIPTION
Motivation
----------
Fixing the PshufbFillPatterns array for use in the SSSE3 optimized route
is expensive.

Modifications
-------------
Fix the array in the outer loop in SnappyDecompressor.DecompressAllTags
and pass the pointer IncrementalCopy. This makes the logic a bit more
confusing, but is a significant performance boost.