### PR TITLE
Support unframed compression/decompression

### DIFF
--- a/Snappier.Benchmarks/CompressAlice.cs
+++ b/Snappier.Benchmarks/CompressAlice.cs
@@ -7,13 +7,12 @@ namespace Snappier.Benchmarks
 {
     //[ShortRunJob(RuntimeMoniker.NetCoreApp21)]
     [ShortRunJob(RuntimeMoniker.NetCoreApp31)]
-    [MemoryDiagnoser]
     public class CompressAlice
     {
         private MemoryStream _source;
         private MemoryStream _destination;
 
-        [Params(1024, 16384, 131072)]
+        [Params(16384, 65536, 131072)]
         public int ReadSize;
 
         [GlobalSetup]
@@ -45,7 +44,7 @@ namespace Snappier.Benchmarks
         {
             _source.Position = 0;
             _destination.Position = 0;
-            using var stream = new Snappy.SnappyStream(_destination, CompressionMode.Compress, true);
+            using var stream = new global::Snappy.SnappyStream(_destination, CompressionMode.Compress, true);
 
             _source.CopyTo(_destination, ReadSize);
         }

--- a/Snappier.Benchmarks/CompressAll.cs
+++ b/Snappier.Benchmarks/CompressAll.cs
@@ -7,7 +7,6 @@ namespace Snappier.Benchmarks
 {
     //[ShortRunJob(RuntimeMoniker.NetCoreApp21)]
     [ShortRunJob(RuntimeMoniker.NetCoreApp31)]
-    [MemoryDiagnoser]
     public class CompressAll
     {
         private MemoryStream _source;
@@ -46,7 +45,7 @@ namespace Snappier.Benchmarks
         {
             _source.Position = 0;
             _destination.Position = 0;
-            using var stream = new Snappy.SnappyStream(_destination, CompressionMode.Compress, true);
+            using var stream = new global::Snappy.SnappyStream(_destination, CompressionMode.Compress, true);
 
             _source.CopyTo(_destination, 65536);
         }

--- a/Snappier.Benchmarks/DecompressAlice.cs
+++ b/Snappier.Benchmarks/DecompressAlice.cs
@@ -7,13 +7,12 @@ namespace Snappier.Benchmarks
 {
     //[ShortRunJob(RuntimeMoniker.NetCoreApp21)]
     [ShortRunJob(RuntimeMoniker.NetCoreApp31)]
-    [MemoryDiagnoser]
     public class DecompressAlice
     {
         private MemoryStream _memoryStream;
         private byte[] _buffer;
 
-        [Params(1024, 16384, 131072)]
+        [Params(16384, 65536, 131072)]
         public int ReadSize;
 
         [GlobalSetup]
@@ -46,7 +45,7 @@ namespace Snappier.Benchmarks
         public void PInvoke()
         {
             _memoryStream.Position = 0;
-            using var stream = new Snappy.SnappyStream(_memoryStream, CompressionMode.Decompress, true);
+            using var stream = new global::Snappy.SnappyStream(_memoryStream, CompressionMode.Decompress, true);
 
             while (stream.Read(_buffer, 0, ReadSize) > 0)
             {

--- a/Snappier.Benchmarks/DecompressAll.cs
+++ b/Snappier.Benchmarks/DecompressAll.cs
@@ -7,7 +7,6 @@ namespace Snappier.Benchmarks
 {
     //[ShortRunJob(RuntimeMoniker.NetCoreApp21)]
     [ShortRunJob(RuntimeMoniker.NetCoreApp31)]
-    [MemoryDiagnoser]
     public class DecompressAll
     {
         private MemoryStream _memoryStream;
@@ -50,7 +49,7 @@ namespace Snappier.Benchmarks
         public void PInvoke()
         {
             _memoryStream.Position = 0;
-            using var stream = new Snappy.SnappyStream(_memoryStream, CompressionMode.Decompress, true);
+            using var stream = new global::Snappy.SnappyStream(_memoryStream, CompressionMode.Decompress, true);
 
             while (stream.Read(_buffer, 0, _buffer.Length) > 0)
             {

--- a/Snappier.Tests/SnappyTests.cs
+++ b/Snappier.Tests/SnappyTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Xunit;
+
+namespace Snappier.Tests
+{
+    public class SnappyTests
+    {
+        [Theory]
+        [InlineData("alice29.txt")]
+        [InlineData("asyoulik.txt")]
+        [InlineData("fireworks.jpeg")]
+        [InlineData("geo.protodata")]
+        [InlineData("html")]
+        [InlineData("html_x_4")]
+        [InlineData("kppkn.gtb")]
+        [InlineData("lcet10.txt")]
+        [InlineData("paper-100k.pdf")]
+        [InlineData("plrabn12.txt")]
+        [InlineData("urls.10K")]
+        public void CompressAndDecompress(string filename)
+        {
+            using var resource =
+                typeof(SnappyStreamTests).Assembly.GetManifestResourceStream($"Snappier.Tests.TestData.{filename}");
+            Assert.NotNull(resource);
+
+            var input = new byte[resource.Length];
+            resource.Read(input);
+
+            var compressed = new byte[Snappy.GetMaxCompressedLength(input.Length)];
+            var compressedLength = Snappy.Compress(input, compressed);
+
+            var compressedSpan = compressed.AsSpan(0, compressedLength);
+
+            var output = new byte[Snappy.GetUncompressedLength(compressedSpan)];
+            var outputLength = Snappy.Decompress(compressedSpan, output);
+
+            Assert.Equal(input.Length, outputLength);
+            Assert.Equal(input, output);
+        }
+    }
+}

--- a/Snappier/Internal/SnappyStreamDecompressor.cs
+++ b/Snappier/Internal/SnappyStreamDecompressor.cs
@@ -101,15 +101,14 @@ namespace Snappier.Internal
                                             chunkSize - chunkBytesProcessed);
                                         Debug.Assert(availableChunkBytes > 0);
 
-                                        _decompressor.SetInput(_input.Slice(unchecked((int) (inputPtr - inputStart)),
-                                            availableChunkBytes));
+
+                                        _decompressor.Decompress(new ReadOnlySpan<byte>(inputPtr, availableChunkBytes));
 
                                         chunkBytesProcessed += availableChunkBytes;
                                         inputPtr += availableChunkBytes;
                                     }
 
-                                    var decompressedBytes =
-                                        _decompressor.Decompress(new Span<byte>(bufferPtr,
+                                    var decompressedBytes = _decompressor.Read(new Span<byte>(bufferPtr,
                                             unchecked((int) (bufferEnd - bufferPtr))));
 
                                     _chunkCrc = Crc32CAlgorithm.Append(_chunkCrc, new ReadOnlySpan<byte>(bufferPtr, decompressedBytes));

--- a/Snappier/Snappy.cs
+++ b/Snappier/Snappy.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.IO;
+using Snappier.Internal;
+
+namespace Snappier
+{
+    /// <summary>
+    /// Routines for performing Snappy compression and decompression on raw data blocks using <see cref="Span{T}"/>.
+    /// These routines do not read or write any Snappy framing.
+    /// </summary>
+    public static class Snappy
+    {
+        /// <summary>
+        /// For a given amount of input data, calculate the maximum potential size of the compressed output.
+        /// </summary>
+        /// <param name="inputLength">Length of the input data, in bytes.</param>
+        /// <returns>The maximum potential size of the compressed output.</returns>
+        /// <remarks>
+        /// This is useful for allocating a sufficient output buffer before calling <see cref="Compress"/>.
+        /// </remarks>
+        public static int GetMaxCompressedLength(int inputLength) =>
+            Helpers.MaxCompressedLength(inputLength);
+
+        /// <summary>
+        /// Compress a block of Snappy data.
+        /// </summary>
+        /// <param name="input">Data to compress.</param>
+        /// <param name="output">Buffer to receive the compressed data.</param>
+        /// <returns>Number of bytes written to <paramref name="output"/>.</returns>
+        /// <remarks>
+        /// The output buffer must be large enough to
+        /// </remarks>
+        public static int Compress(ReadOnlySpan<byte> input, Span<byte> output)
+        {
+            var compressor = new SnappyCompressor();
+
+            return compressor.Compress(input, output);
+        }
+
+        /// <summary>
+        /// Get the uncompressed data length from a compressed Snappy block.
+        /// </summary>
+        /// <param name="input">Compressed snappy block.</param>
+        /// <returns>The length of the uncompressed data in the block.</returns>
+        /// <exception cref="InvalidDataException">The data in <paramref name="input"/> has an invalid length.</exception>
+        /// <remarks>
+        /// This is useful for allocating a sufficient output buffer before calling <see cref="Decompress"/>.
+        /// </remarks>
+        public static int GetUncompressedLength(ReadOnlySpan<byte> input) =>
+            SnappyDecompressor.ReadUncompressedLength(input);
+
+        /// <summary>
+        /// Decompress a block of Snappy data. This must be an entire block.
+        /// </summary>
+        /// <param name="input">Data to decompress.</param>
+        /// <param name="output">Buffer to receive the decompressed data.</param>
+        /// <returns>Number of bytes written to <paramref name="output"/>.</returns>
+        public static int Decompress(ReadOnlySpan<byte> input, Span<byte> output)
+        {
+            var decompressor = new SnappyDecompressor();
+
+            decompressor.Decompress(input);
+
+            if (!decompressor.AllDataDecompressed)
+            {
+                throw new InvalidDataException("Incomplete Snappy block");
+            }
+
+            return decompressor.Read(output);
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
Some clients may not care about the streaming protocol and want to
compress or decompress raw blocks. This can be done in a more performant
way by avoiding System.IO.Stream.