### PR TITLE
Add checks and tests for bad data scenarios

### DIFF
--- a/Snappier.Benchmarks/BlockDecompressAlice.cs
+++ b/Snappier.Benchmarks/BlockDecompressAlice.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Snappier.Internal;
+
+namespace Snappier.Benchmarks
+{
+    [MediumRunJob(RuntimeMoniker.NetCoreApp21)]
+    [MediumRunJob(RuntimeMoniker.NetCoreApp31)]
+    public class BlockDecompressAlice
+    {
+        private ReadOnlyMemory<byte> _input;
+
+        [GlobalSetup]
+        public void LoadToMemory()
+        {
+            using var resource =
+                typeof(DecompressAlice).Assembly.GetManifestResourceStream("Snappier.Benchmarks.TestData.alice29.txt");
+
+            var input = new byte[65536]; // Just test the first 64KB
+            // ReSharper disable once PossibleNullReferenceException
+            resource.Read(input);
+
+            var compressed = new byte[Snappy.GetMaxCompressedLength(input.Length)];
+            var compressedLength = Snappy.Compress(input, compressed);
+
+            _input = compressed.AsMemory(0, compressedLength);
+        }
+
+
+        [Benchmark(Baseline = true)]
+        public void Snappier()
+        {
+            var decompressor = new SnappyDecompressor();
+
+            decompressor.Decompress(_input.Span);
+        }
+    }
+}

--- a/Snappier.Tests/SnappyTests.cs
+++ b/Snappier.Tests/SnappyTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using System.Text;
 using Xunit;
 
 namespace Snappier.Tests
@@ -20,7 +22,7 @@ namespace Snappier.Tests
         public void CompressAndDecompress(string filename)
         {
             using var resource =
-                typeof(SnappyStreamTests).Assembly.GetManifestResourceStream($"Snappier.Tests.TestData.{filename}");
+                typeof(SnappyTests).Assembly.GetManifestResourceStream($"Snappier.Tests.TestData.{filename}");
             Assert.NotNull(resource);
 
             var input = new byte[resource.Length];
@@ -36,6 +38,109 @@ namespace Snappier.Tests
 
             Assert.Equal(input.Length, outputLength);
             Assert.Equal(input, output);
+        }
+
+        [Fact]
+        public void BadData_InsufficentOutputBuffer_ThrowsArgumentException()
+        {
+            var input = new byte[100000];
+            Array.Fill(input, (byte) 'A');
+
+            var compressed = new byte[Snappy.GetMaxCompressedLength(input.Length)];
+            var compressedLength = Snappy.Compress(input, compressed);
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var output = new byte[100];
+                Snappy.Decompress(compressed.AsSpan(0, compressedLength), output);
+            });
+        }
+
+        [Fact]
+        public void BadData_SimpleCorruption_ThrowsInvalidDataException()
+        {
+            var input = Encoding.UTF8.GetBytes("making sure we don't crash with corrupted input");
+
+            var compressed = new byte[Snappy.GetMaxCompressedLength(input.Length)];
+            var compressedLength = Snappy.Compress(input, compressed);
+            var compressedSpan = compressed.AsSpan(0, compressedLength);
+
+            // corrupt the data a bit
+            compressedSpan[1]--;
+            compressedSpan[3]++;
+
+            Assert.Throws<InvalidDataException>(() =>
+            {
+                var length = Snappy.GetUncompressedLength(compressed.AsSpan(0, compressedLength));
+                Assert.InRange(length, 0, 1 << 20);
+
+                var output = new byte[length];
+                Snappy.Decompress(compressed.AsSpan(0, compressedLength), output);
+            });
+        }
+
+        [Fact]
+        public void BadData_ShortLength_ThrowsInvalidDataException()
+        {
+            var input = new byte[100000];
+            Array.Fill(input, (byte) 'A');
+
+            var compressed = new byte[Snappy.GetMaxCompressedLength(input.Length)];
+            var compressedLength = Snappy.Compress(input, compressed);
+            var compressedSpan = compressed.AsSpan(0, compressedLength);
+
+            // Set the length header to 0
+            compressedSpan[0] = compressedSpan[1] = compressedSpan[2] = compressedSpan[3] = 0;
+
+            Assert.Throws<InvalidDataException>(() =>
+            {
+                var output = new byte[100000];
+                Snappy.Decompress(compressed, output);
+            });
+        }
+
+        [Fact]
+        public void BadData_LongLength_ThrowsInvalidDataException()
+        {
+            var input = new byte[1000];
+            Array.Fill(input, (byte) 'A');
+
+            var compressed = new byte[Snappy.GetMaxCompressedLength(input.Length)];
+            var compressedLength = Snappy.Compress(input, compressed);
+            var compressedSpan = compressed.AsSpan(0, compressedLength);
+
+            // Set the length header to 16383
+            compressedSpan[0] = 255;
+            compressedSpan[1] = 127;
+
+            Assert.Throws<InvalidDataException>(() =>
+            {
+                var output = new byte[1000];
+                Snappy.Decompress(compressed, output);
+            });
+        }
+
+        [Theory]
+        [InlineData("baddata1.snappy")]
+        [InlineData("baddata2.snappy")]
+        [InlineData("baddata3.snappy")]
+        public void BadData_FromFile_ThrowsInvalidDataException(string filename)
+        {
+            using var resource =
+                typeof(SnappyTests).Assembly.GetManifestResourceStream($"Snappier.Tests.TestData.{filename}");
+            Assert.NotNull(resource);
+
+            var input = new byte[resource.Length];
+            resource.Read(input);
+
+            Assert.Throws<InvalidDataException>(() =>
+            {
+                var length = Snappy.GetUncompressedLength(input);
+                Assert.InRange(length, 0, 1 << 20);
+
+                var output = new byte[length];
+                Snappy.Decompress(input, output);
+            });
         }
     }
 }

--- a/Snappier/Snappy.cs
+++ b/Snappier/Snappy.cs
@@ -66,7 +66,14 @@ namespace Snappier
                 throw new InvalidDataException("Incomplete Snappy block");
             }
 
-            return decompressor.Read(output);
+            var read = decompressor.Read(output);
+
+            if (!decompressor.EndOfFile)
+            {
+                throw new ArgumentException("Output buffer is too small", nameof(output));
+            }
+
+            return read;
         }
     }
 }


### PR DESCRIPTION
This prevents buffer overruns and other badness.

Switched copyOffset to uint instead of int, and _lookbackPosition to
uint instead of long, to reduce typecasting and allow a performance
trick in AppendFromSelf.