### PR TITLE
Better handling of chunks when decoding streaming data.

### DIFF
--- a/Snappier/Internal/SnappyDecompressor.cs
+++ b/Snappier/Internal/SnappyDecompressor.cs
@@ -94,7 +94,7 @@ namespace Snappier.Internal
             bool foundEnd = false;
 
             var i = 0;
-            while (input.Length > 0)
+            while (input.Length > i)
             {
                 byte c = input[i];
                 i += 1;


### PR DESCRIPTION
This PR adds a test generating lots of small chunks in the encoding.
The idea is to stress this part of the code to make bugs easier to spot.

As a result three bugs were fixed:
- Stop reading past input in SnappyDecompressor on chunk boundary.
- Copy buffer into correct inidex of partially created scratch on chunk boundary.
- Reset _scratchLength after use on chunk boundary.