### PR TITLE
Don't read past end of scratch buffer

### DIFF
--- a/Snappier.Tests/Internal/SnappyDecompressorTests.cs
+++ b/Snappier.Tests/Internal/SnappyDecompressorTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Snappier.Internal;
+using Xunit;
+
+namespace Snappier.Tests.Internal
+{
+    public class SnappyDecompressorTests
+    {
+        #region DecompressAllTags
+
+        [Fact]
+        public void DecompressAllTags_ShortInputBufferWhichCopiesToScratch_DoesNotReadPastEndOfScratch()
+        {
+            // Arrange
+
+            var decompressor = new SnappyDecompressor();
+            decompressor.SetExpectedLengthForTest(1024);
+
+            decompressor.WriteToBufferForTest(Enumerable.Range(0, 255).Select(p => (byte) p).ToArray());
+
+            // if in error, decompressor will read the 222, 0, 0 as the next tag and throw a copy offset exception
+            decompressor.LoadScratchForTest(new byte[] { 222, 222, 222, 222, 0, 0 }, 0);
+
+            // Act
+
+            decompressor.DecompressAllTags(new byte[] { 150, 255, 0 });
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
When the incoming input buffer is short, we must make sure that we
properly set inputLimitMinMaxTagLength to prevent buffer overruns.
Otherwise, we'll read past the end of the buffer.

Closes #25