### PR TITLE
Switch Actions to use GitHub env file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,9 @@ jobs:
 
     - name: Install dependencies
       run: dotnet restore
-    - run: echo "::set-env name=VERSION::${GITHUB_REF/refs\/tags\/release\//}"
+    - run: echo "VERSION=${GITHUB_REF/refs\/tags\/release\//}" >> $GITHUB_ENV
       if: ${{ startsWith(github.ref, 'refs/tags/release/') }}
-    - run: echo "::set-env name=VERSION::0.1.0-local"
+    - run: echo "VERSION=0.1.0-local" >> $GITHUB_ENV
       if: ${{ !startsWith(github.ref, 'refs/tags/release/') }}
     - name: Build
       run: dotnet build --configuration Release -p:Version=${{ env.VERSION }} --no-restore


### PR DESCRIPTION
Motivation
----------
Deprecation of the set-env command on STDOUT due to security
vulnerabilities.