### PR TITLE
Use native ints for decompression

### DIFF
--- a/Snappier.Benchmarks/DecompressAlice.cs
+++ b/Snappier.Benchmarks/DecompressAlice.cs
@@ -1,12 +1,10 @@
 ﻿using System.IO;
 using System.IO.Compression;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
 
 namespace Snappier.Benchmarks
 {
-    //[ShortRunJob(RuntimeMoniker.NetCoreApp21)]
-    [ShortRunJob(RuntimeMoniker.NetCoreApp31)]
+    [Config(typeof(StandardConfig))]
     public class DecompressAlice
     {
         private MemoryStream _memoryStream;

--- a/Snappier.Benchmarks/Program.cs
+++ b/Snappier.Benchmarks/Program.cs
@@ -1,10 +1,5 @@
-﻿using System;
+﻿using System.Reflection;
 using BenchmarkDotNet.Running;
+using Snappier.Benchmarks;
 
-namespace Snappier.Benchmarks
-{
-    class Program
-    {
-        static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, new StandardConfig());
-    }
-}
+BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args, new StandardConfig());

--- a/Snappier.Benchmarks/Snappier.Benchmarks.csproj
+++ b/Snappier.Benchmarks/Snappier.Benchmarks.csproj
@@ -1,8 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <PlatformTarget>AnyCPU</PlatformTarget>
 
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Snappier.Benchmarks/StandardConfig.cs
+++ b/Snappier.Benchmarks/StandardConfig.cs
@@ -14,7 +14,6 @@ namespace Snappier.Benchmarks
 
             AddExporter(DefaultExporters.CsvMeasurements);
             AddExporter(DefaultExporters.Csv);
-            AddExporter(DefaultExporters.RPlot);
             AddExporter(DefaultExporters.Markdown);
             AddExporter(DefaultExporters.Html);
 

--- a/Snappier.Benchmarks/X86X64Config.cs
+++ b/Snappier.Benchmarks/X86X64Config.cs
@@ -1,0 +1,34 @@
+﻿using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.CsProj;
+using BenchmarkDotNet.Toolchains.DotNetCli;
+
+namespace Snappier.Benchmarks
+{
+    public class X86X64Config : StandardConfig
+    {
+        public X86X64Config()
+        {
+            var dotnetCli32Bit = NetCoreAppSettings
+                .NetCoreApp50
+                .WithCustomDotNetCliPath(@"C:\Program Files (x86)\dotnet\dotnet.exe", "32 bit cli");
+
+            var dotnetCli64Bit = NetCoreAppSettings
+                .NetCoreApp50
+                .WithCustomDotNetCliPath(@"C:\Program Files\dotnet\dotnet.exe", "64 bit cli");
+
+            AddJob(Job.MediumRun
+                .WithToolchain(CsProjCoreToolchain.From(dotnetCli32Bit))
+                .WithPlatform(Platform.X86)
+                .WithId("x86"));
+            AddJob(Job.MediumRun
+                .WithToolchain(CsProjCoreToolchain.From(dotnetCli64Bit))
+                .WithPlatform(Platform.X64)
+                .WithId("x64"));
+
+            AddDiagnoser(new DisassemblyDiagnoser(
+                new DisassemblyDiagnoserConfig(maxDepth: 2, printSource: true, exportDiff: true)));
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
Improve decompression performance in x86 mode.

Modifications
-------------
Use native integers, which allows us to transparently use IntPtr or
UIntPtr sized to the pointer size of the platform.

Results
-------
An approximately 14% reduction in run time and 8% reduction in code size
on 32 bit architectures when block-decompressing alice29.txt. The
64 bit platform is currently slightly larger but runtime is equivalent.