### PR TITLE
Add .NET 5 ARM intrinsics for CRC32C

### DIFF
--- a/Snappier/Internal/CopyHelpers.cs
+++ b/Snappier/Internal/CopyHelpers.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0 || NET5_0
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 using static System.Runtime.Intrinsics.X86.Sse2;
@@ -64,7 +64,7 @@ namespace Snappier.Internal
 
             if (patternSize < 8)
             {
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0 || NET5_0
                 if (Ssse3.IsSupported) // SSSE3
                 {
                     // Load the first eight bytes into an 128-bit XMM register, then use PSHUFB
@@ -141,7 +141,7 @@ namespace Snappier.Internal
                         IncrementalCopySlow(source, op, opEnd);
                         return;
                     }
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0 || NET5_0
                 }
 #endif
             }

--- a/Snappier/Internal/Helpers.cs
+++ b/Snappier/Internal/Helpers.cs
@@ -2,7 +2,7 @@
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0 || NET5_0
 using System.Numerics;
 using System.Runtime.Intrinsics.X86;
 #endif
@@ -67,7 +67,7 @@ namespace Snappier.Internal
             Debug.Assert(numBytes >= 0);
             Debug.Assert(numBytes <= 4);
 
-            #if NETCOREAPP3_0
+            #if NETCOREAPP3_0 || NET5_0
             if (Bmi2.IsSupported)
             {
                 return Bmi2.ZeroHighBits(value, (uint)(numBytes * 8));
@@ -144,7 +144,7 @@ namespace Snappier.Internal
         {
             Debug.Assert(n != 0);
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0 || NET5_0
             return BitOperations.Log2(n);
 #else
             return (int) Math.Floor(Math.Log(n, 2));
@@ -159,7 +159,7 @@ namespace Snappier.Internal
         {
             Debug.Assert(n != 0);
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0 || NET5_0
             return BitOperations.TrailingZeroCount(n);
 #else
             int rc = 31;

--- a/Snappier/Internal/SnappyStreamCompressor.cs
+++ b/Snappier/Internal/SnappyStreamCompressor.cs
@@ -150,7 +150,7 @@ namespace Snappier.Internal
 
             ReadOnlyMemory<byte> output = _outputBuffer.Slice(0, _outputBufferSize);
 
-#if NETCOREAPP3_0 || NETSTANDARD2_1
+#if NETCOREAPP3_0 || NET5_0 || NETSTANDARD2_1
             stream.Write(output.Span);
 #else
             if (MemoryMarshal.TryGetArray(output, out var arraySegment))
@@ -184,7 +184,7 @@ namespace Snappier.Internal
 
             ReadOnlyMemory<byte> output = _outputBuffer.Slice(0, _outputBufferSize);
 
-#if NETCOREAPP3_0 || NETSTANDARD2_1
+#if NETCOREAPP3_0  || NET5_0 || NETSTANDARD2_1
             await stream.WriteAsync(output, cancellationToken).ConfigureAwait(false);
 #else
             if (MemoryMarshal.TryGetArray(output, out var arraySegment))

--- a/Snappier/Snappier.csproj
+++ b/Snappier/Snappier.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework> <!-- Don't nag about the netcoreapp3.0 target -->
 
     <LangVersion>9</LangVersion>
@@ -46,7 +46,7 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Motivation
----------
Improve performance when using ARM processors with .NET 5 using the new
ARM intrinsics.