### PR TITLE
Add random data tests to catch more edge cases

### DIFF
--- a/Snappier.Tests/Internal/SnappyDecompressorTests.cs
+++ b/Snappier.Tests/Internal/SnappyDecompressorTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Snappier.Internal;
 using Xunit;
 
@@ -27,6 +25,109 @@ namespace Snappier.Tests.Internal
             // Act
 
             decompressor.DecompressAllTags(new byte[] { 150, 255, 0 });
+
+        }
+
+        #endregion
+
+        #region ExtractData
+
+        [Fact]
+        public void ExtractData_NoLength_InvalidOperationException()
+        {
+            // Arrange
+
+            using var decompressor = new SnappyDecompressor();
+
+            // Act/Assert
+
+            var ex = Assert.Throws<InvalidOperationException>(() => decompressor.ExtractData());
+
+            Assert.Equal("No data present.", ex.Message);
+        }
+
+        [Fact]
+        public void ExtractData_NotFullDecompressed_InvalidOperationException()
+        {
+            // Arrange
+
+            using var decompressor = new SnappyDecompressor();
+
+            using var compressed = Snappy.CompressToMemory(new byte[] {1, 2, 3, 4});
+
+            // Only length is forwarded
+            decompressor.Decompress(compressed.Memory.Span.Slice(0, 1));
+
+            // Act/Assert
+
+            var ex = Assert.Throws<InvalidOperationException>(() => decompressor.ExtractData());
+            Assert.Equal("Block is not fully decompressed.", ex.Message);
+        }
+
+        [Fact]
+        public void ExtractData_ZeroLength_EmptyMemory()
+        {
+            // Arrange
+
+            using var decompressor = new SnappyDecompressor();
+
+            using var compressed = Snappy.CompressToMemory(Array.Empty<byte>());
+
+            decompressor.Decompress(compressed.Memory.Span);
+
+            // Act
+
+            using var result = decompressor.ExtractData();
+
+            // Assert
+
+            Assert.Equal(0, result.Memory.Length);
+        }
+
+        [Fact]
+        public void ExtractData_SomeData_Memory()
+        {
+            // Arrange
+
+            using var decompressor = new SnappyDecompressor();
+
+            using var compressed = Snappy.CompressToMemory(new byte[] {1, 2, 3, 4});
+
+            decompressor.Decompress(compressed.Memory.Span);
+
+            // Act
+
+            using var result = decompressor.ExtractData();
+
+            // Assert
+
+            Assert.Equal(4, result.Memory.Length);
+        }
+
+        [Fact]
+        public void ExtractData_SomeData_DoesResetForReuse()
+        {
+            // Arrange
+
+            using var decompressor = new SnappyDecompressor();
+
+            using var compressed = Snappy.CompressToMemory(new byte[] {1, 2, 3, 4});
+            using var compressed2 = Snappy.CompressToMemory(new byte[] {4, 3, 2, 1});
+
+            decompressor.Decompress(compressed.Memory.Span);
+
+            // Act
+
+            using var result = decompressor.ExtractData();
+
+            decompressor.Decompress(compressed2.Memory.Span);
+
+            using var result2 = decompressor.ExtractData();
+
+            // Assert
+
+            Assert.Equal(4, result2.Memory.Length);
+            Assert.Equal(new byte[] {4, 3, 2, 1}, result2.Memory.ToArray() );
         }
 
         #endregion

--- a/Snappier/Internal/EmptyMemoryOwner.cs
+++ b/Snappier/Internal/EmptyMemoryOwner.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Buffers;
+
+namespace Snappier.Internal
+{
+    /// <summary>
+    /// A fake owner wrapping an empty <see cref="Memory{T}"/>.
+    /// </summary>
+    internal sealed class EmptyMemoryOwner : IMemoryOwner<byte>
+    {
+        private bool _disposed;
+
+        /// <inheritdoc />
+        public void Dispose() => _disposed = true;
+
+        /// <inheritdoc />
+        public Memory<byte> Memory
+        {
+            get
+            {
+                if (_disposed)
+                {
+                    throw new ObjectDisposedException(nameof(EmptyMemoryOwner));
+                }
+
+                return Memory<byte>.Empty;
+            }
+        }
+    }
+}

--- a/Snappier/Internal/SnappyDecompressor.cs
+++ b/Snappier/Internal/SnappyDecompressor.cs
@@ -620,9 +620,14 @@ namespace Snappier.Internal
         public IMemoryOwner<byte> ExtractData()
         {
             var data = _lookbackBufferOwner;
-            if (!ExpectedLength.HasValue || _lookbackBufferOwner is null)
+            if (!ExpectedLength.HasValue)
             {
                 throw new InvalidOperationException("No data present.");
+            }
+            else if (_lookbackBufferOwner == null)
+            {
+                // Length was 0, so we've allocated nothing
+                return new EmptyMemoryOwner();
             }
 
             if (!AllDataDecompressed)
@@ -635,8 +640,10 @@ namespace Snappier.Internal
                 data = new SlicedMemoryOwner(data, ExpectedLength.Value);
             }
 
-            // Clear owner so we don't dispose it in Reset
+            // Clear owner so we don't dispose it
             _lookbackBufferOwner = null;
+            _lookbackBuffer = Memory<byte>.Empty;
+
             Reset();
 
             return data;


### PR DESCRIPTION
Based on the random data tests found in the Snappy C++ implementation.

Fixed an edge case bug around empty SnappyDecompressor.ExtractData that
the tests found, and added more unit tests around that method.