### PR TITLE
Manually unroll the compression loop

### DIFF
--- a/Snappier.Benchmarks/CompressHtml.cs
+++ b/Snappier.Benchmarks/CompressHtml.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using Snappier.Internal;
+
+namespace Snappier.Benchmarks
+{
+    [Config(typeof(FrameworkCompareConfig))]
+    public class CompressHtml
+    {
+        private ReadOnlyMemory<byte> _buffer;
+        private Memory<byte> _buffer2;
+
+        private SnappyCompressor _snappyCompressor;
+        //private SnappyCompressor2 _snappyCompressor2;
+
+        public void GlobalSetup()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using var resource =
+                typeof(DecompressAlice).Assembly.GetManifestResourceStream("Snappier.Benchmarks.TestData.html");
+
+            // ReSharper disable once PossibleNullReferenceException
+            resource.CopyTo(memoryStream);
+
+            _buffer = memoryStream.ToArray().AsMemory();
+            _buffer2 = new byte[Helpers.MaxCompressedLength(_buffer.Length)].AsMemory();
+        }
+
+        [GlobalSetup(Target = nameof(Snappier))]
+        public void SnappierSetup()
+        {
+            GlobalSetup();
+
+            _snappyCompressor = new SnappyCompressor();
+        }
+
+        //[GlobalSetup(Target = nameof(Snappier2))]
+        //public void Snappier2Setup()
+        //{
+        //    GlobalSetup();
+
+        //    _snappyCompressor2 = new SnappyCompressor2();
+        //}
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _snappyCompressor?.Dispose();
+            //_snappyCompressor2?.Dispose();
+        }
+
+        [Benchmark(Baseline = true)]
+        public void Snappier()
+        {
+            _snappyCompressor.Compress(_buffer.Span, _buffer2.Span);
+        }
+
+        //[Benchmark]
+        //public void Snappier2()
+        //{
+        //    _snappyCompressor2.Compress(_buffer.Span, _buffer2.Span);
+        //}
+    }
+}


### PR DESCRIPTION
This provides a slight perf boost on .NET Core 3.1 and .NET 5.0. Though
it is a smidge slower on the legacy .NET Core 2.1 platform for some
reason (probably JIT).

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-9750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.102
  [Host]        : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT
  .NET 5.0      : .NET Core 5.0.2 (CoreCLR 5.0.220.61120, CoreFX 5.0.220.61120), X64 RyuJIT
  .NET Core 2.1 : .NET Core 2.1.24 (CoreCLR 4.6.29518.01, CoreFX 4.6.29518.01), X64 RyuJIT
  .NET Core 3.1 : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT

IterationCount=15  LaunchCount=2  WarmupCount=10

|    Method |           Job |       Runtime |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank |
|---------- |-------------- |-------------- |---------:|--------:|--------:|------:|--------:|-----:|
|  Snappier |      .NET 5.0 | .NET Core 5.0 | 135.0 us | 1.55 us | 2.17 us |  1.00 |    0.00 |    2 |
| Snappier2 |      .NET 5.0 | .NET Core 5.0 | 129.5 us | 0.46 us | 0.67 us |  0.96 |    0.02 |    1 |
|           |               |               |          |         |         |       |         |      |
|  Snappier | .NET Core 2.1 | .NET Core 2.1 | 195.4 us | 0.39 us | 0.54 us |  1.00 |    0.00 |    1 |
| Snappier2 | .NET Core 2.1 | .NET Core 2.1 | 208.4 us | 0.37 us | 0.54 us |  1.07 |    0.00 |    2 |
|           |               |               |          |         |         |       |         |      |
|  Snappier | .NET Core 3.1 | .NET Core 3.1 | 136.9 us | 0.37 us | 0.55 us |  1.00 |    0.00 |    2 |
| Snappier2 | .NET Core 3.1 | .NET Core 3.1 | 128.3 us | 0.25 us | 0.35 us |  0.94 |    0.00 |    1 |