### PR TITLE
Add .NET 6.0 target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '6.0.x'
+    - name: Setup .NET 5.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
     - name: Setup .NET Core 3.1
       if: matrix.framework == 'netcoreapp3.1'
       uses: actions/setup-dotnet@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,6 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '6.0.x'
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'
     - name: Setup .NET Core 3.1
       if: matrix.framework == 'netcoreapp3.1'
       uses: actions/setup-dotnet@v1
@@ -52,10 +48,12 @@ jobs:
 
     - name: Install dependencies
       run: dotnet restore
+    - name: Build dependencies
+      run: dotnet build --no-restore -f ${{ matrix.framework }}  --configuration Release --verbosity normal
     - name: Test
       run: |
         export COMPlus_Enable${{ matrix.disable }}=0 && \
-        dotnet test -f ${{ matrix.framework }} --configuration Release --verbosity normal --logger "junit;LogFilePath=test-results/results.xml"
+        dotnet test --no-build -f ${{ matrix.framework }} --configuration Release --verbosity normal --logger "junit;LogFilePath=test-results/results.xml"
 
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@f8a3fca6035d817e664cd0bf57d7fefc407847ee # pre-1.4, adds comment_on_pr option

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,8 +48,8 @@ jobs:
 
     - name: Install dependencies
       run: dotnet restore
-    - name: Build dependencies
-      run: dotnet build --no-restore -f ${{ matrix.framework }}  --configuration Release --verbosity normal
+    - name: Build
+      run: dotnet build --configuration Release --verbosity normal
     - name: Test
       run: |
         export COMPlus_Enable${{ matrix.disable }}=0 && \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,20 +53,15 @@ jobs:
     - name: Test
       run: |
         export COMPlus_Enable${{ matrix.disable }}=0 && \
-        dotnet test --no-build -f ${{ matrix.framework }} --configuration Release --verbosity normal --logger "junit;LogFilePath=test-results/results.xml"
+        dotnet test --no-build -f ${{ matrix.framework }} --configuration Release --verbosity normal --logger "trx;LogFileName=results.trx"
 
-    - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action@f8a3fca6035d817e664cd0bf57d7fefc407847ee # pre-1.4, adds comment_on_pr option
-      if: >
-        github.event_name == 'push' ||
-        github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    - name: Test Report
+      uses: dorny/test-reporter@v1
+      if: success() || failure() # run this step even if previous step failed
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: Unit Tests ${{ matrix.framework }} Enable${{ matrix.disable }}=0
-        files: '**/test-results/**/*.xml'
-        report_individual_runs: true
-        comment_on_pr: false
-
+        name: Unit Tests
+        path: "**/results.trx"
+        reporter: dotnet-trx
 
   publish:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        framework: ["net5.0", "netcoreapp3.1", "netcoreapp2.1"]
+        framework: ["net6.0", "netcoreapp3.1", "netcoreapp2.1"]
         disable: ["HWIntrinsics", "SSSE3", "BMI2", "Noop"]
         exclude:
           - framework: "netcoreapp2.1"
@@ -24,10 +24,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET 5.0
+    - name: Setup .NET 6.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '6.0.x'
     - name: Setup .NET Core 3.1
       if: matrix.framework == 'netcoreapp3.1'
       uses: actions/setup-dotnet@v1
@@ -38,6 +38,13 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '2.1.x'
+    # Cache packages for faster subsequent runs
+    - uses: actions/cache@v2
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
 
     - name: Install dependencies
       run: dotnet restore
@@ -67,10 +74,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET 5.0
+    - name: Setup .NET 6.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '6.0.x'
 
     - name: Install dependencies
       run: dotnet restore

--- a/Snappier.Benchmarks/Snappier.Benchmarks.csproj
+++ b/Snappier.Benchmarks/Snappier.Benchmarks.csproj
@@ -4,10 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <!-- Don't nag about the netcoreapp2.1 target, we need to use it to test netstandard2.0 targets -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
 
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>9</LangVersion>
+    <LangVersion>10</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Snappier.snk</AssemblyOriginatorKeyFile>
     <NoWarn>$(NoWarn);8002</NoWarn> <!-- Don't nag about Snappy.NET not being strong named -->

--- a/Snappier.Benchmarks/Snappier.Benchmarks.csproj
+++ b/Snappier.Benchmarks/Snappier.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
 
     <IsPackable>false</IsPackable>
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1" />
     <PackageReference Include="Snappy.NET" Version="1.1.1.8" />
   </ItemGroup>
 

--- a/Snappier.Tests/Snappier.Tests.csproj
+++ b/Snappier.Tests/Snappier.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</TargetFrameworks>
@@ -7,7 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>9</LangVersion>
+    <LangVersion>10</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Snappier.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/Snappier.Tests/Snappier.Tests.csproj
+++ b/Snappier.Tests/Snappier.Tests.csproj
@@ -1,7 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</TargetFrameworks>
+    <!-- Don't nag about the netcoreapp2.1 target, we need to use it to test netstandard2.0 targets -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
 
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Snappier/Internal/CopyHelpers.cs
+++ b/Snappier/Internal/CopyHelpers.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_0 || NET5_0
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 using static System.Runtime.Intrinsics.X86.Sse2;
@@ -64,7 +64,7 @@ namespace Snappier.Internal
 
             if (patternSize < 8)
             {
-#if NETCOREAPP3_0 || NET5_0
+#if NETCOREAPP3_0_OR_GREATER
                 if (Ssse3.IsSupported) // SSSE3
                 {
                     // Load the first eight bytes into an 128-bit XMM register, then use PSHUFB
@@ -141,7 +141,7 @@ namespace Snappier.Internal
                         IncrementalCopySlow(source, op, opEnd);
                         return;
                     }
-#if NETCOREAPP3_0 || NET5_0
+#if NETCOREAPP3_0_OR_GREATER
                 }
 #endif
             }

--- a/Snappier/Internal/Crc32CAlgorithm.cs
+++ b/Snappier/Internal/Crc32CAlgorithm.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if NET5_0
+#if NET5_0_OR_GREATER
 using System.Runtime.Intrinsics.Arm;
 #endif
-#if NETCOREAPP3_0 || NET5_0
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Intrinsics.X86;
 #endif
 
@@ -46,7 +46,7 @@ namespace Snappier.Internal
         {
             uint crcLocal = uint.MaxValue ^ crc;
 
-            #if NET5_0
+            #if NET5_0_OR_GREATER
             // If available on the current CPU, use ARM CRC32C intrinsic operations.
             // The if Crc32 statements are optimized out by the JIT compiler based on CPU support.
             if (Crc32.IsSupported)
@@ -78,7 +78,7 @@ namespace Snappier.Internal
             }
             #endif
 
-            #if NETCOREAPP3_0 || NET5_0
+            #if NETCOREAPP3_0_OR_GREATER
             // If available on the current CPU, use Intel CRC32C intrinsic operations.
             // The Sse42 if statements are optimized out by the JIT compiler based on CPU support.
             if (Sse42.IsSupported)

--- a/Snappier/Internal/Helpers.cs
+++ b/Snappier/Internal/Helpers.cs
@@ -2,7 +2,7 @@
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_0 || NET5_0
+#if NETCOREAPP3_0_OR_GREATER
 using System.Numerics;
 using System.Runtime.Intrinsics.X86;
 #endif
@@ -67,7 +67,7 @@ namespace Snappier.Internal
             Debug.Assert(numBytes >= 0);
             Debug.Assert(numBytes <= 4);
 
-            #if NETCOREAPP3_0 || NET5_0
+            #if NETCOREAPP3_0_OR_GREATER
             if (Bmi2.IsSupported)
             {
                 return Bmi2.ZeroHighBits(value, (uint)(numBytes * 8));
@@ -144,7 +144,7 @@ namespace Snappier.Internal
         {
             Debug.Assert(n != 0);
 
-#if NETCOREAPP3_0 || NET5_0
+#if NETCOREAPP3_0_OR_GREATER
             return BitOperations.Log2(n);
 #else
             return (int) Math.Floor(Math.Log(n, 2));
@@ -159,7 +159,7 @@ namespace Snappier.Internal
         {
             Debug.Assert(n != 0);
 
-#if NETCOREAPP3_0 || NET5_0
+#if NETCOREAPP3_0_OR_GREATER
             return BitOperations.TrailingZeroCount(n);
 #else
             int rc = 31;

--- a/Snappier/Internal/SnappyDecompressor.cs
+++ b/Snappier/Internal/SnappyDecompressor.cs
@@ -622,7 +622,7 @@ namespace Snappier.Internal
         /// </remarks>
         public IMemoryOwner<byte> ExtractData()
         {
-            var data = _lookbackBufferOwner;
+            var data = _lookbackBufferOwner!;
             if (!ExpectedLength.HasValue)
             {
                 throw new InvalidOperationException("No data present.");

--- a/Snappier/Internal/SnappyStreamCompressor.cs
+++ b/Snappier/Internal/SnappyStreamCompressor.cs
@@ -150,7 +150,7 @@ namespace Snappier.Internal
 
             ReadOnlyMemory<byte> output = _outputBuffer.Slice(0, _outputBufferSize);
 
-#if NETCOREAPP3_0 || NET5_0 || NETSTANDARD2_1
+#if NETCOREAPP3_0_OR_GREATER || NETSTANDARD2_1
             stream.Write(output.Span);
 #else
             if (MemoryMarshal.TryGetArray(output, out var arraySegment))
@@ -184,7 +184,7 @@ namespace Snappier.Internal
 
             ReadOnlyMemory<byte> output = _outputBuffer.Slice(0, _outputBufferSize);
 
-#if NETCOREAPP3_0  || NET5_0 || NETSTANDARD2_1
+#if NETCOREAPP3_0_OR_GREATER || NETSTANDARD2_1
             await stream.WriteAsync(output, cancellationToken).ConfigureAwait(false);
 #else
             if (MemoryMarshal.TryGetArray(output, out var arraySegment))

--- a/Snappier/Snappier.csproj
+++ b/Snappier/Snappier.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework> <!-- Don't nag about the netcoreapp3.0 target -->
 
-    <LangVersion>9</LangVersion>
+    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Motivation
----------
Allow the use of .NET 6 specific optimizations and use the latest SDK
to build.

Modifications
-------------
- Add a .NET 6 target to the library
- Fix conditional compilation directives to correctly include .NET 6
- Switch unit tests from .NET 5 to 6
- Upgrade build scripting to use the .NET 6 SDK.