### PR TITLE
Remove support for unsupported runtimes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       uses: dorny/test-reporter@v1
       if: success() || failure() # run this step even if previous step failed
       with:
-        name: Unit Tests
+        name: Unit Tests ${{ matrix.framework }} ${{ matrix.disable }}
         path: "**/results.trx"
         reporter: dotnet-trx
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,34 +12,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        framework: ["net6.0", "netcoreapp3.1", "netcoreapp2.1"]
+        framework: ["net6.0", "net7.0"]
         disable: ["HWIntrinsics", "SSSE3", "BMI2", "Noop"]
-        exclude:
-          - framework: "netcoreapp2.1"
-            disable: "HWIntrinsics"
-          - framework: "netcoreapp2.1"
-            disable: "SSSE3"
-          - framework: "netcoreapp2.1"
-            disable: "BMI2"
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET 6.0
-      uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v3
+    - name: Setup .NET 7
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '7.0.x'
+    - name: Setup .NET 6
+      if: matrix.framework == 'net6.0'
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '6.0.x'
-    - name: Setup .NET Core 3.1
-      if: matrix.framework == 'netcoreapp3.1'
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-    - name: Setup .NET Core 2.1
-      if: matrix.framework == 'netcoreapp2.1'
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '2.1.x'
     # Cache packages for faster subsequent runs
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -70,11 +58,11 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/release/') }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET 6.0
-      uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v3
+    - name: Setup .NET 7
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '7.0.x'
 
     - name: Install dependencies
       run: dotnet restore

--- a/Snappier.Benchmarks/BlockDecompressAlice.cs
+++ b/Snappier.Benchmarks/BlockDecompressAlice.cs
@@ -5,8 +5,10 @@ using Snappier.Internal;
 
 namespace Snappier.Benchmarks
 {
-    [MediumRunJob(RuntimeMoniker.NetCoreApp21)]
-    [MediumRunJob(RuntimeMoniker.NetCoreApp31)]
+    [MediumRunJob(RuntimeMoniker.Net48)]
+    [MediumRunJob(RuntimeMoniker.Net60)]
+    [MediumRunJob(RuntimeMoniker.Net70)]
+    [DisassemblyDiagnoser]
     public class BlockDecompressAlice
     {
         private ReadOnlyMemory<byte> _input;

--- a/Snappier.Benchmarks/BlockDecompressAlice.cs
+++ b/Snappier.Benchmarks/BlockDecompressAlice.cs
@@ -19,7 +19,7 @@ namespace Snappier.Benchmarks
 
             var input = new byte[65536]; // Just test the first 64KB
             // ReSharper disable once PossibleNullReferenceException
-            resource.Read(input);
+            resource.Read(input, 0, input.Length);
 
             var compressed = new byte[Snappy.GetMaxCompressedLength(input.Length)];
             var compressedLength = Snappy.Compress(input, compressed);

--- a/Snappier.Benchmarks/CompressAlice.cs
+++ b/Snappier.Benchmarks/CompressAlice.cs
@@ -5,8 +5,8 @@ using BenchmarkDotNet.Jobs;
 
 namespace Snappier.Benchmarks
 {
-    //[ShortRunJob(RuntimeMoniker.NetCoreApp21)]
-    [ShortRunJob(RuntimeMoniker.NetCoreApp31)]
+    //[ShortRunJob(RuntimeMoniker.Net60)]
+    [ShortRunJob(RuntimeMoniker.Net70)]
     public class CompressAlice
     {
         private MemoryStream _source;

--- a/Snappier.Benchmarks/CompressAll.cs
+++ b/Snappier.Benchmarks/CompressAll.cs
@@ -5,8 +5,8 @@ using BenchmarkDotNet.Jobs;
 
 namespace Snappier.Benchmarks
 {
-    //[ShortRunJob(RuntimeMoniker.NetCoreApp21)]
-    [ShortRunJob(RuntimeMoniker.NetCoreApp31)]
+    //[ShortRunJob(RuntimeMoniker.Net60)]
+    [ShortRunJob(RuntimeMoniker.Net70)]
     public class CompressAll
     {
         private MemoryStream _source;

--- a/Snappier.Benchmarks/Crc32CAlgorithm.cs
+++ b/Snappier.Benchmarks/Crc32CAlgorithm.cs
@@ -4,8 +4,8 @@ using BenchmarkDotNet.Jobs;
 
 namespace Snappier.Benchmarks
 {
-    [SimpleJob(RuntimeMoniker.NetCoreApp21, baseline: true)]
-    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
+    [SimpleJob(RuntimeMoniker.Net60, baseline: true)]
+    [SimpleJob(RuntimeMoniker.Net70)]
     public class Crc32CAlgorithm
     {
         private byte[] _buffer;

--- a/Snappier.Benchmarks/DecompressAll.cs
+++ b/Snappier.Benchmarks/DecompressAll.cs
@@ -5,8 +5,8 @@ using BenchmarkDotNet.Jobs;
 
 namespace Snappier.Benchmarks
 {
-    //[ShortRunJob(RuntimeMoniker.NetCoreApp21)]
-    [ShortRunJob(RuntimeMoniker.NetCoreApp31)]
+    //[ShortRunJob(RuntimeMoniker.Net60)]
+    [ShortRunJob(RuntimeMoniker.Net70)]
     public class DecompressAll
     {
         private MemoryStream _memoryStream;

--- a/Snappier.Benchmarks/FrameworkCompareConfig.cs
+++ b/Snappier.Benchmarks/FrameworkCompareConfig.cs
@@ -8,14 +8,14 @@ namespace Snappier.Benchmarks
         public FrameworkCompareConfig()
         {
             AddJob(Job.MediumRun
-                .WithRuntime(CoreRuntime.Core21)
-                .WithId(".NET Core 2.1"));
+                .WithRuntime(ClrRuntime.Net48)
+                .WithId(".NET 4.8"));
             AddJob(Job.MediumRun
-                .WithRuntime(CoreRuntime.Core31)
-                .WithId(".NET Core 3.1"));
+                .WithRuntime(CoreRuntime.Core60)
+                .WithId(".NET 6.0"));
             AddJob(Job.MediumRun
-                .WithRuntime(CoreRuntime.Core50)
-                .WithId(".NET 5.0"));
+                .WithRuntime(CoreRuntime.Core70)
+                .WithId(".NET 7.0"));
         }
     }
 }

--- a/Snappier.Benchmarks/Snappier.Benchmarks.csproj
+++ b/Snappier.Benchmarks/Snappier.Benchmarks.csproj
@@ -2,14 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <!-- Don't nag about the netcoreapp2.1 target, we need to use it to test netstandard2.0 targets -->
-    <CheckEolTargetFramework>false</CheckEolTargetFramework>
 
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>10</LangVersion>
+    <LangVersion>11</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Snappier.snk</AssemblyOriginatorKeyFile>
     <NoWarn>$(NoWarn);8002</NoWarn> <!-- Don't nag about Snappy.NET not being strong named -->
@@ -22,9 +20,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1" />
-    <PackageReference Include="Snappy.NET" Version="1.1.1.8" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.4" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.4" />
+    <PackageReference Include="Crc32C.NET" Version="1.0.5">
+      <NoWarn>NU1701</NoWarn>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Snappy.NET" Version="1.1.1.8">
+      <NoWarn>NU1701</NoWarn>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Snappier.Tests/Snappier.Tests.csproj
+++ b/Snappier.Tests/Snappier.Tests.csproj
@@ -1,13 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</TargetFrameworks>
-    <!-- Don't nag about the netcoreapp2.1 target, we need to use it to test netstandard2.0 targets -->
-    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>10</LangVersion>
+    <LangVersion>11</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Snappier.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/Snappier/Internal/CopyHelpers.cs
+++ b/Snappier/Internal/CopyHelpers.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_0_OR_GREATER
+#if NET6_0_OR_GREATER
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 using static System.Runtime.Intrinsics.X86.Sse2;
@@ -64,7 +64,7 @@ namespace Snappier.Internal
 
             if (patternSize < 8)
             {
-#if NETCOREAPP3_0_OR_GREATER
+#if NET6_0_OR_GREATER
                 if (Ssse3.IsSupported) // SSSE3
                 {
                     // Load the first eight bytes into an 128-bit XMM register, then use PSHUFB
@@ -141,7 +141,7 @@ namespace Snappier.Internal
                         IncrementalCopySlow(source, op, opEnd);
                         return;
                     }
-#if NETCOREAPP3_0_OR_GREATER
+#if NET6_0_OR_GREATER
                 }
 #endif
             }

--- a/Snappier/Internal/Crc32CAlgorithm.cs
+++ b/Snappier/Internal/Crc32CAlgorithm.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+#if NET6_0_OR_GREATER
 using System.Runtime.InteropServices;
-#if NET5_0_OR_GREATER
 using System.Runtime.Intrinsics.Arm;
-#endif
-#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Intrinsics.X86;
 #endif
 
@@ -46,7 +44,7 @@ namespace Snappier.Internal
         {
             uint crcLocal = uint.MaxValue ^ crc;
 
-            #if NET5_0_OR_GREATER
+            #if NET6_0_OR_GREATER
             // If available on the current CPU, use ARM CRC32C intrinsic operations.
             // The if Crc32 statements are optimized out by the JIT compiler based on CPU support.
             if (Crc32.IsSupported)
@@ -76,12 +74,10 @@ namespace Snappier.Internal
 
                 return crcLocal ^ uint.MaxValue;
             }
-            #endif
 
-            #if NETCOREAPP3_0_OR_GREATER
             // If available on the current CPU, use Intel CRC32C intrinsic operations.
             // The Sse42 if statements are optimized out by the JIT compiler based on CPU support.
-            if (Sse42.IsSupported)
+            else if (Sse42.IsSupported)
             {
                 // Process in 8-byte chunks first if 64-bit
                 if (Sse42.X64.IsSupported)

--- a/Snappier/Internal/Helpers.cs
+++ b/Snappier/Internal/Helpers.cs
@@ -2,7 +2,7 @@
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_0_OR_GREATER
+#if NET6_0_OR_GREATER
 using System.Numerics;
 using System.Runtime.Intrinsics.X86;
 #endif
@@ -67,7 +67,7 @@ namespace Snappier.Internal
             Debug.Assert(numBytes >= 0);
             Debug.Assert(numBytes <= 4);
 
-            #if NETCOREAPP3_0_OR_GREATER
+            #if NET6_0_OR_GREATER
             if (Bmi2.IsSupported)
             {
                 return Bmi2.ZeroHighBits(value, (uint)(numBytes * 8));
@@ -144,7 +144,7 @@ namespace Snappier.Internal
         {
             Debug.Assert(n != 0);
 
-#if NETCOREAPP3_0_OR_GREATER
+#if NET6_0_OR_GREATER
             return BitOperations.Log2(n);
 #else
             return (int) Math.Floor(Math.Log(n, 2));
@@ -159,7 +159,7 @@ namespace Snappier.Internal
         {
             Debug.Assert(n != 0);
 
-#if NETCOREAPP3_0_OR_GREATER
+#if NET6_0_OR_GREATER
             return BitOperations.TrailingZeroCount(n);
 #else
             int rc = 31;

--- a/Snappier/Internal/SnappyStreamCompressor.cs
+++ b/Snappier/Internal/SnappyStreamCompressor.cs
@@ -150,7 +150,7 @@ namespace Snappier.Internal
 
             ReadOnlyMemory<byte> output = _outputBuffer.Slice(0, _outputBufferSize);
 
-#if NETCOREAPP3_0_OR_GREATER || NETSTANDARD2_1
+#if NET6_0_OR_GREATER
             stream.Write(output.Span);
 #else
             if (MemoryMarshal.TryGetArray(output, out var arraySegment))
@@ -184,7 +184,7 @@ namespace Snappier.Internal
 
             ReadOnlyMemory<byte> output = _outputBuffer.Slice(0, _outputBufferSize);
 
-#if NETCOREAPP3_0_OR_GREATER || NETSTANDARD2_1
+#if NET6_0_OR_GREATER
             await stream.WriteAsync(output, cancellationToken).ConfigureAwait(false);
 #else
             if (MemoryMarshal.TryGetArray(output, out var arraySegment))

--- a/Snappier/Snappier.csproj
+++ b/Snappier/Snappier.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;net5.0;net6.0</TargetFrameworks>
-    <CheckEolTargetFramework>false</CheckEolTargetFramework> <!-- Don't nag about the netcoreapp3.0 target -->
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
 
-    <LangVersion>10</LangVersion>
+    <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
.NET Core 3.0/3.1 and .NET 5 are no longer supported by Microsoft, and we can simplify the codebase by not including them. .NET Standard 2.1 is really only used for .NET Core 2.1 which is also unsupported, so we can remove that as well. We'll retain .NET Standard 2.0 for continued support of the legacy full framework.