### PR TITLE
Preload Pshufb fill pattern Vector128

### DIFF
--- a/Snappier.Benchmarks/IncrementalCopy.cs
+++ b/Snappier.Benchmarks/IncrementalCopy.cs
@@ -13,10 +13,7 @@ namespace Snappier.Benchmarks
         {
             fixed (byte* buffer = _buffer)
             {
-                fixed (sbyte* pshufbFillPatterns = CopyHelpers.PshufbFillPatterns)
-                {
-                    CopyHelpers.IncrementalCopy(buffer, buffer + 2, buffer + 18, buffer + _buffer.Length, pshufbFillPatterns);
-                }
+                CopyHelpers.IncrementalCopy(buffer, buffer + 2, buffer + 18, buffer + _buffer.Length);
             }
         }
 


### PR DESCRIPTION
Motivation
----------
This avoids the need to pin the array of fill patterns on every execution and the expense/complication of passing that pointer down through the layers to IncrementalCopy. The pinning is also completely unnecessary in .NET 4.8 which can never use the intrinsics, so we avoid that pointless cost as well.

Modifications
-------------
Replace the sbyte[] array of fill patterns with preloaded Vector128 instances in an array. Drop the use of pinning and passing the pinned pointer down to IncrementalCopy.

Results
-------
Simpler code and a minor perf gain.

BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22000.1455/21H2) Intel Core i7-10850H CPU 2.70GHz, 1 CPU, 12 logical and 6 physical cores .NET SDK=7.0.102
  [Host]                     : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  LongRun-.NET 6.0           : .NET 6.0.13 (6.0.1322.58009), X64 RyuJIT AVX2
  LongRun-.NET 7.0           : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  LongRun-.NET Framework 4.8 : .NET Framework 4.8 (4.8.4515.0), X64 RyuJIT VectorSize=256

IterationCount=100  LaunchCount=3  WarmupCount=15

|    Method |                        Job |            Runtime |      Mean |    Error |   StdDev |    Median | Ratio | RatioSD |
|---------- |--------------------------- |------------------- |----------:|---------:|---------:|----------:|------:|--------:|
|  Snappier |           LongRun-.NET 6.0 |           .NET 6.0 | 111.80 us | 0.455 us | 2.373 us | 111.87 us |  1.00 |    0.00 |
| Snappier2 |           LongRun-.NET 6.0 |           .NET 6.0 | 110.31 us | 0.525 us | 2.735 us | 110.35 us |  0.99 |    0.03 |
|           |                            |                    |           |          |          |           |       |         |
|  Snappier |           LongRun-.NET 7.0 |           .NET 7.0 | 113.22 us | 0.578 us | 3.005 us | 113.09 us |  1.00 |    0.00 |
| Snappier2 |           LongRun-.NET 7.0 |           .NET 7.0 | 109.59 us | 1.086 us | 5.653 us | 108.28 us |  0.97 |    0.05 |
|           |                            |                    |           |          |          |           |       |         |
|  Snappier | LongRun-.NET Framework 4.8 | .NET Framework 4.8 |  85.91 us | 1.032 us | 5.380 us |  84.09 us |  1.00 |    0.00 |
| Snappier2 | LongRun-.NET Framework 4.8 | .NET Framework 4.8 |  84.18 us | 0.437 us | 2.275 us |  84.31 us |  0.98 |    0.07 |