### PR TITLE
Make unit tests .NET 4.8 compatible

### DIFF
--- a/Snappier.Tests/Snappier.Tests.csproj
+++ b/Snappier.Tests/Snappier.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net48</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -17,13 +18,13 @@
 
   <ItemGroup>
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Snappier.Tests/SnappyStreamTests.cs
+++ b/Snappier.Tests/SnappyStreamTests.cs
@@ -133,9 +133,9 @@ namespace Snappier.Tests
                 byte[] buffer = new byte[100];
                 var requestedSize = rand.Next(1, buffer.Length);
                 int n;
-                while ((n = inputStream.Read(buffer.AsSpan(0, requestedSize))) != 0)
+                while ((n = inputStream.Read(buffer, 0, requestedSize)) != 0)
                 {
-                    compressor.Write(buffer.AsSpan(0, n));
+                    compressor.Write(buffer, 0, n);
                     // Flush after every write so we get lots of small chunks in the compressed output.
                     compressor.Flush();
                 }

--- a/Snappier.Tests/SnappyTests.cs
+++ b/Snappier.Tests/SnappyTests.cs
@@ -27,7 +27,7 @@ namespace Snappier.Tests
             Assert.NotNull(resource);
 
             var input = new byte[resource.Length];
-            resource.Read(input);
+            resource.Read(input, 0, input.Length);
 
             var compressed = new byte[Snappy.GetMaxCompressedLength(input.Length)];
             var compressedLength = Snappy.Compress(input, compressed);
@@ -72,7 +72,7 @@ namespace Snappier.Tests
         public void BadData_InsufficentOutputBuffer_ThrowsArgumentException()
         {
             var input = new byte[100000];
-            Array.Fill(input, (byte) 'A');
+            ArrayFill(input, (byte) 'A');
 
             var compressed = new byte[Snappy.GetMaxCompressedLength(input.Length)];
             var compressedLength = Snappy.Compress(input, compressed);
@@ -111,7 +111,7 @@ namespace Snappier.Tests
         public void BadData_LongLength_ThrowsInvalidDataException()
         {
             var input = new byte[1000];
-            Array.Fill(input, (byte) 'A');
+            ArrayFill(input, (byte) 'A');
 
             var compressed = new byte[Snappy.GetMaxCompressedLength(input.Length)];
             var compressedLength = Snappy.Compress(input, compressed);
@@ -139,7 +139,7 @@ namespace Snappier.Tests
             Assert.NotNull(resource);
 
             var input = new byte[resource.Length];
-            resource.Read(input);
+            resource.Read(input, 0, input.Length);
 
             Assert.Throws<InvalidDataException>(() =>
             {
@@ -159,7 +159,7 @@ namespace Snappier.Tests
             Assert.NotNull(resource);
 
             var input = new byte[resource.Length];
-            resource.Read(input);
+            resource.Read(input, 0, input.Length);
 
             var compressed = new byte[Snappy.GetMaxCompressedLength(input.Length)];
             var compressedLength = Snappy.Compress(input, compressed);
@@ -206,7 +206,7 @@ namespace Snappier.Tests
                         c = (byte)rng.Next(0, (1 << skewedBits) - 1);
                     }
 
-                    Array.Fill(buffer, c, size, Math.Min(runLength, length - size));
+                    ArrayFill(buffer, c, size, Math.Min(runLength, length - size));
                     size += runLength;
                 }
 
@@ -217,6 +217,27 @@ namespace Snappier.Tests
                 Assert.Equal(buffer.Length, decompressed.Memory.Length);
                 Assert.Equal(buffer, decompressed.Memory.ToArray());
             }
+        }
+
+        private static void ArrayFill(byte[] array, byte value)
+        {
+#if NET48
+            ArrayFill(array, value, 0, array.Length);
+#else
+            Array.Fill(array, value);
+#endif
+        }
+
+        private static void ArrayFill(byte[] array, byte value, int startIndex, int count)
+        {
+#if NET48
+            for (int i = startIndex; i < startIndex + count; i++)
+            {
+                array[i] = value;
+            }
+#else
+            Array.Fill(array, value, startIndex, count);
+#endif
         }
     }
 }


### PR DESCRIPTION
Only available when building/running on Windows.