### PR TITLE
Switch CopyHelpers to use ref byte instead of byte*

### DIFF
--- a/Snappier.Benchmarks/IncrementalCopy.cs
+++ b/Snappier.Benchmarks/IncrementalCopy.cs
@@ -1,4 +1,5 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
 using Snappier.Internal;
 
 namespace Snappier.Benchmarks
@@ -9,21 +10,18 @@ namespace Snappier.Benchmarks
         private readonly byte[] _buffer = new byte[128];
 
         [Benchmark]
-        public unsafe void Fast()
+        public void Fast()
         {
-            fixed (byte* buffer = _buffer)
-            {
-                CopyHelpers.IncrementalCopy(buffer, buffer + 2, buffer + 18, buffer + _buffer.Length);
-            }
+            ref byte buffer = ref _buffer[0];
+            CopyHelpers.IncrementalCopy(ref buffer, ref Unsafe.Add(ref buffer, 2), ref Unsafe.Add(ref buffer, 18),
+                ref Unsafe.Add(ref buffer, _buffer.Length - 1));
         }
 
         [Benchmark(Baseline = true)]
-        public unsafe void SlowCopyMemory()
+        public void SlowCopyMemory()
         {
-            fixed (byte* buffer = _buffer)
-            {
-                CopyHelpers.IncrementalCopySlow(buffer, buffer + 2, buffer + 18);
-            }
+            ref byte buffer = ref _buffer[0];
+            CopyHelpers.IncrementalCopySlow(ref buffer, ref Unsafe.Add(ref buffer, 2), ref Unsafe.Add(ref buffer, 18));
         }
     }
 }

--- a/Snappier.Benchmarks/UnalignedCopy128.cs
+++ b/Snappier.Benchmarks/UnalignedCopy128.cs
@@ -1,4 +1,5 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Diagnostics.Windows.Configs;
 using Snappier.Internal;
 
@@ -13,10 +14,8 @@ namespace Snappier.Benchmarks
         [Benchmark]
         public unsafe void Default()
         {
-            fixed (byte* ptr = _buffer)
-            {
-                CopyHelpers.UnalignedCopy64(ptr, ptr + 8);
-            }
+            ref byte ptr = ref _buffer[0];
+            CopyHelpers.UnalignedCopy64(ref ptr, ref Unsafe.Add(ref ptr, 8));
         }
     }
 }

--- a/Snappier.Benchmarks/UnalignedCopy64.cs
+++ b/Snappier.Benchmarks/UnalignedCopy64.cs
@@ -1,4 +1,5 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Diagnostics.Windows.Configs;
 using Snappier.Internal;
 
@@ -11,12 +12,10 @@ namespace Snappier.Benchmarks
         private readonly byte[] _buffer = new byte[32];
 
         [Benchmark]
-        public unsafe void Default()
+        public void Default()
         {
-            fixed (byte* ptr = _buffer)
-            {
-                CopyHelpers.UnalignedCopy128(ptr, ptr + 16);
-            }
+            ref byte ptr = ref _buffer[0];
+            CopyHelpers.UnalignedCopy128(ref ptr, ref Unsafe.Add(ref ptr,16));
         }
     }
 }

--- a/Snappier/Internal/CopyHelpers.cs
+++ b/Snappier/Internal/CopyHelpers.cs
@@ -63,7 +63,7 @@ namespace Snappier.Internal
         /// to this method. This makes the logic a bit more confusing, but is a significant performance boost.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void IncrementalCopy(ref byte source, ref byte op, ref byte opEnd, ref byte bufferEnd)
+        public static unsafe void IncrementalCopy(ref byte source, ref byte op, ref byte opEnd, ref byte bufferEnd)
         {
             Debug.Assert(Unsafe.IsAddressLessThan(ref source, ref op));
             Debug.Assert(!Unsafe.IsAddressGreaterThan(ref op, ref opEnd));

--- a/Snappier/Internal/SnappyCompressor.cs
+++ b/Snappier/Internal/SnappyCompressor.cs
@@ -188,7 +188,7 @@ namespace Snappier.Internal
                                             if (Helpers.UnsafeReadUInt32(candidate) == dword)
                                             {
                                                 *op = (byte) (Constants.Literal | (j << 2));
-                                                CopyHelpers.UnalignedCopy128(nextEmit, op + 1);
+                                                CopyHelpers.UnalignedCopy128(ref Unsafe.AsRef<byte>(nextEmit), ref Unsafe.AsRef<byte>(op + 1));
                                                 ip += j;
                                                 op = op + j + 2;
                                                 goto emit_match;
@@ -206,7 +206,7 @@ namespace Snappier.Internal
                                             if (Helpers.UnsafeReadUInt32(candidate) == dword)
                                             {
                                                 *op = (byte) (Constants.Literal | (i1 << 2));
-                                                CopyHelpers.UnalignedCopy128(nextEmit, op + 1);
+                                                CopyHelpers.UnalignedCopy128(ref Unsafe.AsRef<byte>(nextEmit), ref Unsafe.AsRef<byte>(op + 1));
                                                 ip += i1;
                                                 op = op + i1 + 2;
                                                 goto emit_match;
@@ -224,7 +224,7 @@ namespace Snappier.Internal
                                             if (Helpers.UnsafeReadUInt32(candidate) == dword)
                                             {
                                                 *op = (byte) (Constants.Literal | (i2 << 2));
-                                                CopyHelpers.UnalignedCopy128(nextEmit, op + 1);
+                                                CopyHelpers.UnalignedCopy128(ref Unsafe.AsRef<byte>(nextEmit), ref Unsafe.AsRef<byte>(op + 1));
                                                 ip += i2;
                                                 op = op + i2 + 2;
                                                 goto emit_match;
@@ -242,7 +242,7 @@ namespace Snappier.Internal
                                             if (Helpers.UnsafeReadUInt32(candidate) == dword)
                                             {
                                                 *op = (byte) (Constants.Literal | (i3 << 2));
-                                                CopyHelpers.UnalignedCopy128(nextEmit, op + 1);
+                                                CopyHelpers.UnalignedCopy128(ref Unsafe.AsRef<byte>(nextEmit), ref Unsafe.AsRef<byte>(op + 1));
                                                 ip += i3;
                                                 op = op + i3 + 2;
                                                 goto emit_match;
@@ -370,7 +370,7 @@ namespace Snappier.Internal
                 uint n = length - 1;
                 *op++ = unchecked((byte)(Constants.Literal | (n << 2)));
 
-                CopyHelpers.UnalignedCopy128(literal, op);
+                CopyHelpers.UnalignedCopy128(ref Unsafe.AsRef<byte>(literal), ref Unsafe.AsRef<byte>(op));
                 return op + length;
             }
 

--- a/Snappier/Snappier.csproj
+++ b/Snappier/Snappier.csproj
@@ -42,11 +42,8 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Motivation
----------
This is a step towards code that doesn't require pinning which can help with GC when compression/decompression is run a lot. GC will be able to move memory even when in the middle of a compression or decompression run and update the ref pointers.

Modifications
-------------
Rewrite all implementations in CopyHelper to use `ref byte` instead of `byte*` and use Unsafe methods to perform pointer arithmetic.

Ensure that the output buffer always contains an extra byte at the end so that `ref byte bufferEnd` will always point to a byte in the array rather than past the end of the array. This ensures that if the buffer is moved GC recognizes that bufferEnd points within the array and updates it accordingly.

Update to System.Runtime.CompilerServices.Unsafe for .NET Standard to gain access to Unsafe.SkipInit.

Results
-------
We actually see some improved performance under this paradigm. Some of this gain is because CopyUnalignedXXX was not consistently inlining due to the use of stackalloc. However, there was gain even above and beyond the inlining improvement.

The drop in performance for .NET 4.8 is unclear, but I suspect a benchmarking problem because the .NET 4.8 implementation should have been slower than .NET 6/7 in the first place.

### Benchmark for block decompression of Alice

BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22000.1455/21H2) Intel Core i7-10850H CPU 2.70GHz, 1 CPU, 12 logical and 6 physical cores .NET SDK=7.0.102
  [Host]                       : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  MediumRun-.NET 6.0           : .NET 6.0.13 (6.0.1322.58009), X64 RyuJIT AVX2
  MediumRun-.NET 7.0           : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  MediumRun-.NET Framework 4.8 : .NET Framework 4.8 (4.8.4515.0), X64 RyuJIT VectorSize=256

IterationCount=15  LaunchCount=2  WarmupCount=10

|  Method |                          Job |            Runtime |      Mean |    Error |   StdDev |    Median | Ratio | RatioSD | Code Size |
|-------- |----------------------------- |------------------- |----------:|---------:|---------:|----------:|------:|--------:|----------:|
| Pointer |           MediumRun-.NET 6.0 |           .NET 6.0 | 110.58 us | 0.336 us | 0.460 us | 110.61 us |  1.00 |    0.00 |     805 B |
|     Ref |           MediumRun-.NET 6.0 |           .NET 6.0 | 107.62 us | 1.072 us | 1.537 us | 106.70 us |  0.97 |    0.01 |     805 B |
|         |                              |                    |           |          |          |           |       |         |           |
| Pointer |           MediumRun-.NET 7.0 |           .NET 7.0 | 110.06 us | 1.538 us | 2.156 us | 108.52 us |  1.00 |    0.00 |     780 B |
|     Ref |           MediumRun-.NET 7.0 |           .NET 7.0 | 104.60 us | 1.565 us | 2.294 us | 103.53 us |  0.95 |    0.02 |     780 B |
|         |                              |                    |           |          |          |           |       |         |           |
| Pointer | MediumRun-.NET Framework 4.8 | .NET Framework 4.8 |  83.92 us | 1.088 us | 1.628 us |  83.22 us |  1.00 |    0.00 |   1,376 B |
|     Ref | MediumRun-.NET Framework 4.8 | .NET Framework 4.8 | 116.98 us | 0.119 us | 0.170 us | 117.03 us |  1.40 |    0.02 |   1,376 B |

### Benchmark for IncrementalCopy

BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22000.1455/21H2) Intel Core i7-10850H CPU 2.70GHz, 1 CPU, 12 logical and 6 physical cores .NET SDK=7.0.102
  [Host]                       : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  MediumRun-.NET 6.0           : .NET 6.0.13 (6.0.1322.58009), X64 RyuJIT AVX2
  MediumRun-.NET 7.0           : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  MediumRun-.NET Framework 4.8 : .NET Framework 4.8 (4.8.4515.0), X64 RyuJIT VectorSize=256

IterationCount=15  LaunchCount=2  WarmupCount=10

|  Method |                          Job |            Runtime |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |
|-------- |----------------------------- |------------------- |----------:|----------:|----------:|----------:|------:|--------:|
| Pointer |           MediumRun-.NET 6.0 |           .NET 6.0 |  3.775 ns | 0.0245 ns | 0.0343 ns |  3.771 ns |  1.00 |    0.00 |
|     Ref |           MediumRun-.NET 6.0 |           .NET 6.0 |  3.601 ns | 0.0882 ns | 0.1320 ns |  3.538 ns |  0.95 |    0.04 |
|         |                              |                    |           |           |           |           |       |         |
| Pointer |           MediumRun-.NET 7.0 |           .NET 7.0 |  4.486 ns | 0.1680 ns | 0.2514 ns |  4.423 ns |  1.00 |    0.00 |
|     Ref |           MediumRun-.NET 7.0 |           .NET 7.0 |  3.272 ns | 0.0597 ns | 0.0856 ns |  3.211 ns |  0.73 |    0.05 |
|         |                              |                    |           |           |           |           |       |         |
| Pointer | MediumRun-.NET Framework 4.8 | .NET Framework 4.8 | 17.711 ns | 0.2031 ns | 0.2978 ns | 17.604 ns |  1.00 |    0.00 |
|     Ref | MediumRun-.NET Framework 4.8 | .NET Framework 4.8 | 17.299 ns | 0.1080 ns | 0.1479 ns | 17.234 ns |  0.98 |    0.01 |

Note: The gains on the IncrementalCopy benchmark are actually somewhat better than shown. In order to get valid comparisons given the API surface change from `byte*` to `ref byte` both versions under test include the overhead of pinning the array. The pinning expense is not a valid real world expense because we never do that on each call to IncrementalCopy.