### PR TITLE
Improve perf of UnalignedCopy64/128

### DIFF
--- a/Snappier.Benchmarks/UnalignedCopy128.cs
+++ b/Snappier.Benchmarks/UnalignedCopy128.cs
@@ -5,17 +5,18 @@ using Snappier.Internal;
 
 namespace Snappier.Benchmarks
 {
+
     [RyuJitX64Job]
     [InliningDiagnoser(false, new[] {"Snappier.Benchmarks"})]
-    public class UnalignedCopy64
+    public class UnalignedCopy128
     {
-        private readonly byte[] _buffer = new byte[16];
+        private readonly byte[] _buffer = new byte[32];
 
         [Benchmark]
-        public unsafe void Default()
+        public void Default()
         {
             ref byte ptr = ref _buffer[0];
-            CopyHelpers.UnalignedCopy64(ref ptr, ref Unsafe.Add(ref ptr, 8));
+            CopyHelpers.UnalignedCopy128(ref ptr, ref Unsafe.Add(ref ptr,16));
         }
     }
 }

--- a/Snappier.Benchmarks/UnalignedCopy64.cs
+++ b/Snappier.Benchmarks/UnalignedCopy64.cs
@@ -1,21 +1,22 @@
 ﻿using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Diagnostics.Windows.Configs;
+using BenchmarkDotNet.Jobs;
 using Snappier.Internal;
 
 namespace Snappier.Benchmarks
 {
     [RyuJitX64Job]
     [InliningDiagnoser(false, new[] {"Snappier.Benchmarks"})]
-    public class UnalignedCopy128
+    public class UnalignedCopy64
     {
-        private readonly byte[] _buffer = new byte[32];
+        private readonly byte[] _buffer = new byte[16];
 
         [Benchmark]
         public void Default()
         {
             ref byte ptr = ref _buffer[0];
-            CopyHelpers.UnalignedCopy128(ref ptr, ref Unsafe.Add(ref ptr,16));
+            CopyHelpers.UnalignedCopy64(ref ptr, ref Unsafe.Add(ref ptr, 8));
         }
     }
 }

--- a/Snappier/Internal/CopyHelpers.cs
+++ b/Snappier/Internal/CopyHelpers.cs
@@ -234,23 +234,15 @@ namespace Snappier.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void UnalignedCopy64(ref byte source, ref byte destination)
         {
-            // Stackalloc may prevent inlining, so use an 8-byte long for the buffer
-            Unsafe.SkipInit(out long tempStackVar);
-            ref byte temp = ref Unsafe.As<long, byte>(ref tempStackVar);
-
-            Unsafe.CopyBlockUnaligned(ref temp, ref source, 8);
-            Unsafe.CopyBlockUnaligned(ref destination, ref temp, 8);
+            long tempStackVar = Unsafe.As<byte, long>(ref source);
+            Unsafe.As<byte, long>(ref destination) = tempStackVar;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void UnalignedCopy128(ref byte source, ref byte destination)
         {
-            // Stackalloc may prevent inlining, so use a 16-byte Guid for the buffer
-            Unsafe.SkipInit(out Guid tempStackVar);
-            ref byte temp = ref Unsafe.As<Guid, byte>(ref tempStackVar);
-
-            Unsafe.CopyBlockUnaligned(ref temp, ref source, 16);
-            Unsafe.CopyBlockUnaligned(ref destination, ref temp, 16);
+            Guid tempStackVar = Unsafe.As<byte, Guid>(ref source);
+            Unsafe.As<byte, Guid>(ref destination) = tempStackVar;
         }
     }
 }


### PR DESCRIPTION
Motivation
----------
There is room for improvement in how JIT handles these operations.

Modifications
-------------
Switch from using block copy operations to direct copy to/from a local temp variable of the correct size.

Results
-------

### IncrementalCopy 16 bytes with extra buffer room

BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22000.1455/21H2) Intel Core i7-10850H CPU 2.70GHz, 1 CPU, 12 logical and 6 physical cores .NET SDK=7.0.102
  [Host]                       : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  MediumRun-.NET 6.0           : .NET 6.0.13 (6.0.1322.58009), X64 RyuJIT AVX2
  MediumRun-.NET 7.0           : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  MediumRun-.NET Framework 4.8 : .NET Framework 4.8 (4.8.4515.0), X64 RyuJIT VectorSize=256

IterationCount=15  LaunchCount=2  WarmupCount=10

| Method |                          Job |            Runtime |      Mean |     Error |    StdDev | Ratio | RatioSD | Code Size |
|------- |----------------------------- |------------------- |----------:|----------:|----------:|------:|--------:|----------:|
|    Old |           MediumRun-.NET 6.0 |           .NET 6.0 |  3.251 ns | 0.0714 ns | 0.1023 ns |  1.00 |    0.00 |     689 B |
|    New |           MediumRun-.NET 6.0 |           .NET 6.0 |  2.955 ns | 0.0159 ns | 0.0239 ns |  0.91 |    0.03 |     496 B |
|        |                              |                    |           |           |           |       |         |           |
|    Old |           MediumRun-.NET 7.0 |           .NET 7.0 |  3.097 ns | 0.1127 ns | 0.1686 ns |  1.00 |    0.00 |     572 B |
|    New |           MediumRun-.NET 7.0 |           .NET 7.0 |  2.981 ns | 0.1097 ns | 0.1573 ns |  0.97 |    0.03 |     423 B |
|        |                              |                    |           |           |           |       |         |           |
|    Old | MediumRun-.NET Framework 4.8 | .NET Framework 4.8 | 16.226 ns | 0.0271 ns | 0.0388 ns |  1.00 |    0.00 |     657 B |
|    New | MediumRun-.NET Framework 4.8 | .NET Framework 4.8 |  8.235 ns | 0.0114 ns | 0.0163 ns |  0.51 |    0.00 |     390 B |

### Block decompression of Alice

BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22000.1455/21H2) Intel Core i7-10850H CPU 2.70GHz, 1 CPU, 12 logical and 6 physical cores .NET SDK=7.0.102
  [Host]                       : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  MediumRun-.NET 6.0           : .NET 6.0.13 (6.0.1322.58009), X64 RyuJIT AVX2
  MediumRun-.NET 7.0           : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  MediumRun-.NET Framework 4.8 : .NET Framework 4.8 (4.8.4515.0), X64 RyuJIT VectorSize=256

IterationCount=15  LaunchCount=2  WarmupCount=10

| Method |                          Job |            Runtime |      Mean |    Error |   StdDev |    Median | Ratio | RatioSD | Code Size |
|------- |----------------------------- |------------------- |----------:|---------:|---------:|----------:|------:|--------:|----------:|
|    Old |           MediumRun-.NET 6.0 |           .NET 6.0 | 109.37 us | 1.141 us | 1.636 us | 108.88 us |  1.00 |    0.00 |     805 B |
|    New |           MediumRun-.NET 6.0 |           .NET 6.0 | 102.41 us | 1.243 us | 1.861 us | 103.44 us |  0.94 |    0.02 |     805 B |
|        |                              |                    |           |          |          |           |       |         |           |
|    Old |           MediumRun-.NET 7.0 |           .NET 7.0 | 105.09 us | 1.413 us | 2.071 us | 105.04 us |  1.00 |    0.00 |     780 B |
|    New |           MediumRun-.NET 7.0 |           .NET 7.0 |  96.04 us | 1.181 us | 1.731 us |  96.32 us |  0.91 |    0.02 |     780 B |
|        |                              |                    |           |          |          |           |       |         |           |
|    Old | MediumRun-.NET Framework 4.8 | .NET Framework 4.8 | 115.33 us | 0.934 us | 1.368 us | 114.85 us |  1.00 |    0.00 |   1,376 B |
|    New | MediumRun-.NET Framework 4.8 | .NET Framework 4.8 | 109.05 us | 1.166 us | 1.634 us | 108.31 us |  0.95 |    0.02 |   1,376 B |