### PR TITLE
Rewrite decompressor AppendXXX methods to use refs

### DIFF
--- a/Snappier.Benchmarks/UnalignedCopy128.cs
+++ b/Snappier.Benchmarks/UnalignedCopy128.cs
@@ -16,7 +16,7 @@ namespace Snappier.Benchmarks
         public void Default()
         {
             ref byte ptr = ref _buffer[0];
-            CopyHelpers.UnalignedCopy128(ref ptr, ref Unsafe.Add(ref ptr,16));
+            CopyHelpers.UnalignedCopy128(in ptr, ref Unsafe.Add(ref ptr,16));
         }
     }
 }

--- a/Snappier.Benchmarks/UnalignedCopy64.cs
+++ b/Snappier.Benchmarks/UnalignedCopy64.cs
@@ -16,7 +16,7 @@ namespace Snappier.Benchmarks
         public void Default()
         {
             ref byte ptr = ref _buffer[0];
-            CopyHelpers.UnalignedCopy64(ref ptr, ref Unsafe.Add(ref ptr, 8));
+            CopyHelpers.UnalignedCopy64(in ptr, ref Unsafe.Add(ref ptr, 8));
         }
     }
 }

--- a/Snappier/Internal/CopyHelpers.cs
+++ b/Snappier/Internal/CopyHelpers.cs
@@ -141,7 +141,7 @@ namespace Snappier.Internal
                     {
                         while (patternSize < 8)
                         {
-                            UnalignedCopy64(ref source, ref op);
+                            UnalignedCopy64(in source, ref op);
                             op = ref Unsafe.Add(ref op, patternSize);
                             patternSize *= 2;
                         }
@@ -173,20 +173,20 @@ namespace Snappier.Internal
             // based on that.
             if (!Unsafe.IsAddressGreaterThan(ref opEnd, ref Unsafe.Subtract(ref bufferEnd, 16)))
             {
-                UnalignedCopy64(ref source, ref op);
-                UnalignedCopy64(ref Unsafe.Add(ref  source, 8), ref Unsafe.Add(ref op, 8));
+                UnalignedCopy64(in source, ref op);
+                UnalignedCopy64(in Unsafe.Add(ref  source, 8), ref Unsafe.Add(ref op, 8));
 
                 if (Unsafe.IsAddressLessThan(ref op, ref Unsafe.Subtract(ref opEnd, 16))) {
-                    UnalignedCopy64(ref Unsafe.Add(ref source, 16), ref Unsafe.Add(ref op, 16));
-                    UnalignedCopy64(ref Unsafe.Add(ref source, 24), ref Unsafe.Add(ref op, 24));
+                    UnalignedCopy64(in Unsafe.Add(ref source, 16), ref Unsafe.Add(ref op, 16));
+                    UnalignedCopy64(in Unsafe.Add(ref source, 24), ref Unsafe.Add(ref op, 24));
                 }
                 if (Unsafe.IsAddressLessThan(ref op, ref Unsafe.Subtract(ref opEnd, 32))) {
-                    UnalignedCopy64(ref Unsafe.Add(ref source, 32), ref Unsafe.Add(ref op, 32));
-                    UnalignedCopy64(ref Unsafe.Add(ref source, 40), ref Unsafe.Add(ref op, 40));
+                    UnalignedCopy64(in Unsafe.Add(ref source, 32), ref Unsafe.Add(ref op, 32));
+                    UnalignedCopy64(in Unsafe.Add(ref source, 40), ref Unsafe.Add(ref op, 40));
                 }
                 if (Unsafe.IsAddressLessThan(ref op, ref Unsafe.Subtract(ref opEnd, 48))) {
-                    UnalignedCopy64(ref Unsafe.Add(ref source, 48), ref Unsafe.Add(ref op, 48));
-                    UnalignedCopy64(ref Unsafe.Add(ref source, 56), ref Unsafe.Add(ref op, 56));
+                    UnalignedCopy64(in Unsafe.Add(ref source, 48), ref Unsafe.Add(ref op, 48));
+                    UnalignedCopy64(in Unsafe.Add(ref source, 56), ref Unsafe.Add(ref op, 56));
                 }
 
                 return;
@@ -199,8 +199,8 @@ namespace Snappier.Internal
                  Unsafe.IsAddressLessThan(ref op, ref loopEnd);
                  op = ref Unsafe.Add(ref op, 16), source = ref Unsafe.Add(ref source, 16))
             {
-                UnalignedCopy64(ref source, ref op);
-                UnalignedCopy64(ref Unsafe.Add(ref source, 8), ref Unsafe.Add(ref op, 8));
+                UnalignedCopy64(in source, ref op);
+                UnalignedCopy64(in Unsafe.Add(ref source, 8), ref Unsafe.Add(ref op, 8));
             }
 
             if (!Unsafe.IsAddressLessThan(ref op, ref opEnd))
@@ -212,7 +212,7 @@ namespace Snappier.Internal
             // single 8 byte copy.
             if (!Unsafe.IsAddressGreaterThan(ref op, ref Unsafe.Subtract(ref bufferEnd, 8)))
             {
-                UnalignedCopy64(ref source, ref op);
+                UnalignedCopy64(in source, ref op);
                 source = ref Unsafe.Add(ref source, 8);
                 op = ref Unsafe.Add(ref op, 8);
             }
@@ -232,16 +232,16 @@ namespace Snappier.Internal
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void UnalignedCopy64(ref byte source, ref byte destination)
+        public static void UnalignedCopy64(in byte source, ref byte destination)
         {
-            long tempStackVar = Unsafe.As<byte, long>(ref source);
+            long tempStackVar = Unsafe.As<byte, long>(ref Unsafe.AsRef(source));
             Unsafe.As<byte, long>(ref destination) = tempStackVar;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void UnalignedCopy128(ref byte source, ref byte destination)
+        public static void UnalignedCopy128(in byte source, ref byte destination)
         {
-            Guid tempStackVar = Unsafe.As<byte, Guid>(ref source);
+            Guid tempStackVar = Unsafe.As<byte, Guid>(ref Unsafe.AsRef(source));
             Unsafe.As<byte, Guid>(ref destination) = tempStackVar;
         }
     }

--- a/Snappier/Internal/SnappyCompressor.cs
+++ b/Snappier/Internal/SnappyCompressor.cs
@@ -188,7 +188,7 @@ namespace Snappier.Internal
                                             if (Helpers.UnsafeReadUInt32(candidate) == dword)
                                             {
                                                 *op = (byte) (Constants.Literal | (j << 2));
-                                                CopyHelpers.UnalignedCopy128(ref Unsafe.AsRef<byte>(nextEmit), ref Unsafe.AsRef<byte>(op + 1));
+                                                CopyHelpers.UnalignedCopy128(in Unsafe.AsRef<byte>(nextEmit), ref Unsafe.AsRef<byte>(op + 1));
                                                 ip += j;
                                                 op = op + j + 2;
                                                 goto emit_match;
@@ -206,7 +206,7 @@ namespace Snappier.Internal
                                             if (Helpers.UnsafeReadUInt32(candidate) == dword)
                                             {
                                                 *op = (byte) (Constants.Literal | (i1 << 2));
-                                                CopyHelpers.UnalignedCopy128(ref Unsafe.AsRef<byte>(nextEmit), ref Unsafe.AsRef<byte>(op + 1));
+                                                CopyHelpers.UnalignedCopy128(in Unsafe.AsRef<byte>(nextEmit), ref Unsafe.AsRef<byte>(op + 1));
                                                 ip += i1;
                                                 op = op + i1 + 2;
                                                 goto emit_match;
@@ -224,7 +224,7 @@ namespace Snappier.Internal
                                             if (Helpers.UnsafeReadUInt32(candidate) == dword)
                                             {
                                                 *op = (byte) (Constants.Literal | (i2 << 2));
-                                                CopyHelpers.UnalignedCopy128(ref Unsafe.AsRef<byte>(nextEmit), ref Unsafe.AsRef<byte>(op + 1));
+                                                CopyHelpers.UnalignedCopy128(in Unsafe.AsRef<byte>(nextEmit), ref Unsafe.AsRef<byte>(op + 1));
                                                 ip += i2;
                                                 op = op + i2 + 2;
                                                 goto emit_match;
@@ -242,7 +242,7 @@ namespace Snappier.Internal
                                             if (Helpers.UnsafeReadUInt32(candidate) == dword)
                                             {
                                                 *op = (byte) (Constants.Literal | (i3 << 2));
-                                                CopyHelpers.UnalignedCopy128(ref Unsafe.AsRef<byte>(nextEmit), ref Unsafe.AsRef<byte>(op + 1));
+                                                CopyHelpers.UnalignedCopy128(in Unsafe.AsRef<byte>(nextEmit), ref Unsafe.AsRef<byte>(op + 1));
                                                 ip += i3;
                                                 op = op + i3 + 2;
                                                 goto emit_match;
@@ -370,7 +370,7 @@ namespace Snappier.Internal
                 uint n = length - 1;
                 *op++ = unchecked((byte)(Constants.Literal | (n << 2)));
 
-                CopyHelpers.UnalignedCopy128(ref Unsafe.AsRef<byte>(literal), ref Unsafe.AsRef<byte>(op));
+                CopyHelpers.UnalignedCopy128(in Unsafe.AsRef<byte>(literal), ref Unsafe.AsRef<byte>(op));
                 return op + length;
             }
 


### PR DESCRIPTION
Motivation
----------
This is a step towards code that doesn't require pinning which can help with GC when compression/decompression is run a lot. GC will be able to move memory even when in the middle of a compression or decompression run and update the ref pointers.

Modifications
-------------
Rewrite all AppendXXX implementations in SnappyDecompressor to use `ref byte` instead of `byte*` and use Unsafe methods to perform pointer arithmetic.

Change source parameter to CopyBlockUnaligned64/128 to be `in` instead of `ref` to simplify usage where the source is a `ReadOnlySpan<byte>`.

Results
-------
We generally see improved performance as well, except for a small regression in .NET 6, which appears to be JIT related. However, overall performance is still better than it was in the previous version and hopefully the regression is resolved when we move forward with further conversions to `ref byte`.

BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22000.1455/21H2) Intel Core i7-10850H CPU 2.70GHz, 1 CPU, 12 logical and 6 physical cores .NET SDK=7.0.102
  [Host]                       : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  MediumRun-.NET 6.0           : .NET 6.0.13 (6.0.1322.58009), X64 RyuJIT AVX2
  MediumRun-.NET 7.0           : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  MediumRun-.NET Framework 4.8 : .NET Framework 4.8 (4.8.4515.0), X64 RyuJIT VectorSize=256

IterationCount=15  LaunchCount=2  WarmupCount=10

|  Method |                          Job |            Runtime |      Mean |    Error |   StdDev | Ratio |
|-------- |----------------------------- |------------------- |----------:|---------:|---------:|------:|
| Pointer |           MediumRun-.NET 6.0 |           .NET 6.0 | 102.31 us | 0.196 us | 0.287 us |  1.00 |
|     Ref |           MediumRun-.NET 6.0 |           .NET 6.0 | 105.67 us | 0.509 us | 0.697 us |  1.03 |
|         |                              |                    |           |          |          |       |
| Pointer |           MediumRun-.NET 7.0 |           .NET 7.0 |  96.65 us | 0.131 us | 0.193 us |  1.00 |
|     Ref |           MediumRun-.NET 7.0 |           .NET 7.0 |  91.92 us | 0.179 us | 0.262 us |  0.95 |
|         |                              |                    |           |          |          |       |
| Pointer | MediumRun-.NET Framework 4.8 | .NET Framework 4.8 | 108.61 us | 0.805 us | 1.181 us |  1.00 |
|     Ref | MediumRun-.NET Framework 4.8 | .NET Framework 4.8 | 105.75 us | 0.113 us | 0.155 us |  0.98 |