### PR TITLE
Use ThrowHelper for all exceptions

### DIFF
--- a/Snappier/Internal/CallerArgumentExpressionAttribute.cs
+++ b/Snappier/Internal/CallerArgumentExpressionAttribute.cs
@@ -1,0 +1,19 @@
+﻿#if !NET6_0_OR_GREATER
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    internal sealed class CallerArgumentExpressionAttribute : Attribute
+    {
+        public CallerArgumentExpressionAttribute(string parameterName)
+        {
+            ParameterName = parameterName;
+        }
+
+        public string ParameterName { get; }
+    }
+}
+#endif

--- a/Snappier/Internal/EmptyMemoryOwner.cs
+++ b/Snappier/Internal/EmptyMemoryOwner.cs
@@ -20,7 +20,7 @@ namespace Snappier.Internal
             {
                 if (_disposed)
                 {
-                    throw new ObjectDisposedException(nameof(EmptyMemoryOwner));
+                    ThrowHelper.ThrowObjectDisposedException(nameof(EmptyMemoryOwner));
                 }
 
                 return Memory<byte>.Empty;

--- a/Snappier/Internal/SlicedMemoryOwner.cs
+++ b/Snappier/Internal/SlicedMemoryOwner.cs
@@ -18,7 +18,7 @@ namespace Snappier.Internal
             {
                 if (_innerMemoryOwner == null)
                 {
-                    throw new ObjectDisposedException(nameof(SlicedMemoryOwner));
+                    ThrowHelper.ThrowObjectDisposedException(nameof(SlicedMemoryOwner));
                 }
 
                 return _innerMemoryOwner.Memory.Slice(0, _length);
@@ -27,13 +27,13 @@ namespace Snappier.Internal
 
         public SlicedMemoryOwner(IMemoryOwner<byte> innerMemoryOwner, int length)
         {
-            _innerMemoryOwner = innerMemoryOwner ?? throw new ArgumentNullException(nameof(innerMemoryOwner));
-
-            if (_length > _innerMemoryOwner.Memory.Length)
+            ThrowHelper.ThrowIfNull(innerMemoryOwner);
+            if (_length > innerMemoryOwner.Memory.Length)
             {
-                throw new ArgumentException($"{nameof(length)} is greater than the inner length.", nameof(length));
+                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(length), $"{nameof(length)} is greater than the inner length.");
             }
 
+            _innerMemoryOwner = innerMemoryOwner;
             _length = length;
         }
 

--- a/Snappier/Internal/SnappyCompressor.cs
+++ b/Snappier/Internal/SnappyCompressor.cs
@@ -7,17 +7,17 @@ namespace Snappier.Internal
 {
     internal class SnappyCompressor : IDisposable
     {
-        private HashTable? _workingMemory = new HashTable();
+        private HashTable? _workingMemory = new();
 
         public int Compress(ReadOnlySpan<byte> input, Span<byte> output)
         {
             if (output.Length < Helpers.MaxCompressedLength(input.Length))
             {
-                throw new ArgumentException("Insufficient output buffer", nameof(output));
+                ThrowHelper.ThrowArgumentException("Insufficient output buffer", nameof(output));
             }
             if (_workingMemory == null)
             {
-                throw new ObjectDisposedException(nameof(SnappyCompressor));
+                ThrowHelper.ThrowObjectDisposedException(nameof(SnappyCompressor));
             }
 
             _workingMemory.EnsureCapacity(input.Length);

--- a/Snappier/Internal/SnappyDecompressor.cs
+++ b/Snappier/Internal/SnappyDecompressor.cs
@@ -102,7 +102,7 @@ namespace Snappier.Internal
                 int val = c & 0x7f;
                 if (Helpers.LeftShiftOverflows((byte) val, shift))
                 {
-                    throw new InvalidOperationException("Invalid stream length");
+                    ThrowHelper.ThrowInvalidOperationException("Invalid stream length");
                 }
 
                 result |= val << shift;
@@ -117,7 +117,7 @@ namespace Snappier.Internal
 
                 if (shift >= 32)
                 {
-                    throw new InvalidOperationException("Invalid stream length");
+                    ThrowHelper.ThrowInvalidOperationException("Invalid stream length");
                 }
             }
 
@@ -149,7 +149,7 @@ namespace Snappier.Internal
                 int val = c & 0x7f;
                 if (Helpers.LeftShiftOverflows((byte) val, shift))
                 {
-                    throw new InvalidDataException("Invalid stream length");
+                    ThrowHelper.ThrowInvalidDataException("Invalid stream length");
                 }
 
                 result |= val << shift;
@@ -164,13 +164,13 @@ namespace Snappier.Internal
 
                 if (shift >= 32)
                 {
-                    throw new InvalidDataException("Invalid stream length");
+                    ThrowHelper.ThrowInvalidDataException("Invalid stream length");
                 }
             }
 
             if (!foundEnd)
             {
-                throw new InvalidDataException("Invalid stream length");
+                ThrowHelper.ThrowInvalidDataException("Invalid stream length");
             }
 
             return result;
@@ -596,20 +596,10 @@ namespace Snappier.Internal
         {
             if (length > Unsafe.ByteOffset(ref op, ref bufferEnd))
             {
-                ThrowInvalidDataException("Data too long");
+                ThrowHelper.ThrowInvalidDataException("Data too long");
             }
 
             Unsafe.CopyBlockUnaligned(ref op, ref Unsafe.AsRef(in input), (uint) length);
-        }
-
-        /// <summary>
-        /// Throws an <see cref="ThrowInvalidDataException"/>. This is in a separate subroutine to allow the
-        /// calling subroutine to be inlined.
-        /// </summary>
-        /// <param name="message">Exception message.</param>
-        private static void ThrowInvalidDataException(string message)
-        {
-            throw new InvalidDataException(message);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -631,12 +621,12 @@ namespace Snappier.Internal
             ref byte source = ref Unsafe.Subtract(ref op, copyOffset);
             if (!Unsafe.IsAddressLessThan(ref source, ref op) || Unsafe.IsAddressLessThan(ref source, ref buffer))
             {
-                ThrowInvalidDataException("Invalid copy offset");
+                ThrowHelper.ThrowInvalidDataException("Invalid copy offset");
             }
 
             if (length > Unsafe.ByteOffset(ref op, ref bufferEnd))
             {
-                ThrowInvalidDataException("Data too long");
+                ThrowHelper.ThrowInvalidDataException("Data too long");
             }
 
             CopyHelpers.IncrementalCopy(ref source, ref op,
@@ -679,7 +669,7 @@ namespace Snappier.Internal
             var data = _lookbackBufferOwner!;
             if (!ExpectedLength.HasValue)
             {
-                throw new InvalidOperationException("No data present.");
+                ThrowHelper.ThrowInvalidOperationException("No data present.");
             }
             else if (_lookbackBufferOwner == null)
             {
@@ -689,7 +679,7 @@ namespace Snappier.Internal
 
             if (!AllDataDecompressed)
             {
-                throw new InvalidOperationException("Block is not fully decompressed.");
+                ThrowHelper.ThrowInvalidOperationException("Block is not fully decompressed.");
             }
 
             if (data.Memory.Length > ExpectedLength.Value)
@@ -724,7 +714,8 @@ namespace Snappier.Internal
         /// </summary>
         internal void LoadScratchForTest(byte[] newScratch, uint newScratchLength)
         {
-            _scratch = newScratch ?? throw new ArgumentNullException(nameof(newScratch));
+            ThrowHelper.ThrowIfNull(newScratch);
+            _scratch = newScratch;
             _scratchLength = newScratchLength;
         }
 

--- a/Snappier/Internal/SnappyStreamCompressor.cs
+++ b/Snappier/Internal/SnappyStreamCompressor.cs
@@ -41,13 +41,10 @@ namespace Snappier.Internal
         /// <returns>A block of memory with compressed data (if any). Must be used before any subsequent call to Write.</returns>
         public void Write(ReadOnlySpan<byte> input, Stream stream)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
+            ThrowHelper.ThrowIfNull(stream);
             if (_compressor == null)
             {
-                throw new ObjectDisposedException(nameof(SnappyStreamCompressor));
+                ThrowHelper.ThrowObjectDisposedException(nameof(SnappyStreamCompressor));
             }
 
             EnsureBuffer();
@@ -72,13 +69,10 @@ namespace Snappier.Internal
         /// <returns>A block of memory with compressed data (if any). Must be used before any subsequent call to Write.</returns>
         public async ValueTask WriteAsync(ReadOnlyMemory<byte> input, Stream stream, CancellationToken cancellationToken = default)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
+            ThrowHelper.ThrowIfNull(stream);
             if (_compressor == null)
             {
-                throw new ObjectDisposedException(nameof(SnappyStreamCompressor));
+                ThrowHelper.ThrowObjectDisposedException(nameof(SnappyStreamCompressor));
             }
 
             EnsureBuffer();
@@ -95,13 +89,10 @@ namespace Snappier.Internal
 
         public void Flush(Stream stream)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
+            ThrowHelper.ThrowIfNull(stream);
             if (_compressor == null)
             {
-                throw new ObjectDisposedException(nameof(SnappyStreamCompressor));
+                ThrowHelper.ThrowObjectDisposedException(nameof(SnappyStreamCompressor));
             }
 
             EnsureBuffer();
@@ -118,13 +109,10 @@ namespace Snappier.Internal
 
         public async ValueTask FlushAsync(Stream stream, CancellationToken cancellationToken = default)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
+            ThrowHelper.ThrowIfNull(stream);
             if (_compressor == null)
             {
-                throw new ObjectDisposedException(nameof(SnappyStreamCompressor));
+                ThrowHelper.ThrowObjectDisposedException(nameof(SnappyStreamCompressor));
             }
 
             EnsureBuffer();

--- a/Snappier/Internal/ThrowHelper.cs
+++ b/Snappier/Internal/ThrowHelper.cs
@@ -1,14 +1,51 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Runtime.CompilerServices;
 
 namespace Snappier.Internal
 {
     internal static class ThrowHelper
     {
         [DoesNotReturn]
-        public static void ThrowInvalidOperationException(string message)
+        public static void ThrowArgumentException(string? message, string? paramName) =>
+            throw new ArgumentException(message, paramName);
+
+        [DoesNotReturn]
+        public static void ThrowArgumentOutOfRangeException(string? paramName, string? message) =>
+            throw new ArgumentOutOfRangeException(paramName, message);
+
+#if NET6_0_OR_GREATER
+        public static void ThrowIfNull([NotNull] object? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null) =>
+            ArgumentNullException.ThrowIfNull(argument, paramName);
+#else
+        [DoesNotReturn]
+        private static void ThrowArgumentNullException(string? paramName) =>
+            throw new ArgumentNullException(paramName);
+
+        public static void ThrowIfNull([NotNull] object? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
         {
-            throw new InvalidOperationException(message);
+            if (argument is null)
+            {
+                ThrowArgumentNullException(paramName);
+            }
         }
+#endif
+
+        [DoesNotReturn]
+        public static void ThrowInvalidDataException(string? message) =>
+            throw new InvalidDataException(message);
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException(string? message) =>
+            throw new InvalidOperationException(message);
+
+        [DoesNotReturn]
+        public static void ThrowNotSupportedException() =>
+            throw new NotSupportedException();
+
+        [DoesNotReturn]
+        public static void ThrowObjectDisposedException(string? objectName) =>
+            throw new ObjectDisposedException(objectName);
     }
 }

--- a/Snappier/Snappy.cs
+++ b/Snappier/Snappy.cs
@@ -109,14 +109,14 @@ namespace Snappier
 
             if (!decompressor.AllDataDecompressed)
             {
-                throw new InvalidDataException("Incomplete Snappy block.");
+                ThrowHelper.ThrowInvalidDataException("Incomplete Snappy block.");
             }
 
-            var read = decompressor.Read(output);
+            int read = decompressor.Read(output);
 
             if (!decompressor.EndOfFile)
             {
-                throw new ArgumentException("Output buffer is too small.", nameof(output));
+                ThrowHelper.ThrowArgumentException("Output buffer is too small.", nameof(output));
             }
 
             return read;
@@ -138,7 +138,7 @@ namespace Snappier
 
             if (!decompressor.AllDataDecompressed)
             {
-                throw new InvalidDataException("Incomplete Snappy block.");
+                ThrowHelper.ThrowInvalidDataException("Incomplete Snappy block.");
             }
 
             return decompressor.ExtractData();


### PR DESCRIPTION
Motivation
----------
Using a ThrowHelper routine to throw exceptions generally reduces overall JIT code size and allows more frequent JIT inlining.

Modifications
-------------
- Create ThrowHelper routines for all exceptions we throw.
- Move some existing helpers from private methods to ThrowHelper.
- Add a local version of ArgumentNullException.ThrowIfNull that simply forwards for .NET 6/7 but has a local implementation for .NET Standard.
- Add CallerArgumentExpression attribute for .NET Standard only.