### PR TITLE
Allow shorter compression output buffer lengths

### DIFF
--- a/Snappier.Benchmarks/BlockCompressHtml.cs
+++ b/Snappier.Benchmarks/BlockCompressHtml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using Snappier.Internal;
+
+namespace Snappier.Benchmarks
+{
+    public class BlockCompressHtml
+    {
+        private ReadOnlyMemory<byte> _input;
+        private Memory<byte> _output;
+
+        [GlobalSetup]
+        public void LoadToMemory()
+        {
+            using var resource =
+                typeof(BlockCompressHtml).Assembly.GetManifestResourceStream("Snappier.Benchmarks.TestData.html");
+
+            byte[] input = new byte[65536]; // Just test the first 64KB
+            int inputLength = resource!.Read(input, 0, input.Length);
+            _input = input.AsMemory(0, inputLength);
+
+            _output = new byte[65536];
+        }
+
+        [Benchmark]
+        public int Compress()
+        {
+            using var compressor = new SnappyCompressor();
+
+            return compressor.Compress(_input.Span, _output.Span);
+        }
+    }
+}

--- a/Snappier/Internal/SnappyCompressor.cs
+++ b/Snappier/Internal/SnappyCompressor.cs
@@ -11,10 +11,6 @@ namespace Snappier.Internal
 
         public int Compress(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            if (output.Length < Helpers.MaxCompressedLength(input.Length))
-            {
-                ThrowHelper.ThrowArgumentException("Insufficient output buffer", nameof(output));
-            }
             if (_workingMemory == null)
             {
                 ThrowHelper.ThrowObjectDisposedException(nameof(SnappyCompressor));
@@ -46,6 +42,10 @@ namespace Snappier.Internal
                     try
                     {
                         int written = CompressFragment(fragment, scratch.AsSpan(), hashTable);
+                        if (output.Length < written)
+                        {
+                            ThrowHelper.ThrowArgumentException("Insufficient output buffer", nameof(output));
+                        }
 
                         scratch.AsSpan(0, written).CopyTo(output);
                         output = output.Slice(written);


### PR DESCRIPTION
Motivation
----------
The current implementation requires that the compression output buffer have enough room for the maximum possible compressed block size, which is very unlikely to be required.

Modifications
-------------
Check the remaining output buffer size before outputting each fragment to the buffer.

Add a benchmark for block compression.

Results
-------
An exception is only thrown if the output buffer is insufficient for the actual compressed size.