### PR TITLE
Fix compression stream benchmarks

### DIFF
--- a/Snappier.Benchmarks/CompressAll.cs
+++ b/Snappier.Benchmarks/CompressAll.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO;
 using System.IO.Compression;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
 
 namespace Snappier.Benchmarks
 {
@@ -27,7 +26,6 @@ namespace Snappier.Benchmarks
             resource.CopyTo(_source);
         }
 
-
         [Benchmark]
         public void Compress()
         {
@@ -35,7 +33,8 @@ namespace Snappier.Benchmarks
             _destination.Position = 0;
             using var stream = new SnappyStream(_destination, CompressionMode.Compress, true);
 
-            _source.CopyTo(_destination, 65536);
+            _source.CopyTo(stream, 65536);
+            stream.Flush();
         }
     }
 }

--- a/Snappier.Benchmarks/CompressHtml.cs
+++ b/Snappier.Benchmarks/CompressHtml.cs
@@ -32,7 +32,8 @@ namespace Snappier.Benchmarks
             _destination.Position = 0;
             using var stream = new SnappyStream(_destination, CompressionMode.Compress, true);
 
-            _source.CopyTo(_destination, ReadSize);
+            _source.CopyTo(stream, ReadSize);
+            stream.Flush();
         }
     }
 }


### PR DESCRIPTION
Motivation
----------
The current benchmarks are invalid because they are failing to flush the stream so all data is not compressed. This particularly skews the results for some implementations of Stream.CopyTo on some runtimes.

Modifications
-------------
Add a Flush() call.