### PR TITLE
Improve block benchmarks

### DIFF
--- a/Snappier.Benchmarks/BlockCompressHtml.cs
+++ b/Snappier.Benchmarks/BlockCompressHtml.cs
@@ -15,11 +15,11 @@ namespace Snappier.Benchmarks
             using var resource =
                 typeof(BlockCompressHtml).Assembly.GetManifestResourceStream("Snappier.Benchmarks.TestData.html");
 
-            byte[] input = new byte[65536]; // Just test the first 64KB
+            byte[] input = new byte[resource!.Length];
             int inputLength = resource!.Read(input, 0, input.Length);
             _input = input.AsMemory(0, inputLength);
 
-            _output = new byte[65536];
+            _output = new byte[Snappy.GetMaxCompressedLength(inputLength)];
         }
 
         [Benchmark]

--- a/Snappier.Benchmarks/Configuration/VersionComparisonConfig.cs
+++ b/Snappier.Benchmarks/Configuration/VersionComparisonConfig.cs
@@ -51,9 +51,8 @@ namespace Snappier.Benchmarks.Configuration
             public IEnumerable<BenchmarkCase> GetExecutionOrder(ImmutableArray<BenchmarkCase> benchmarksCase,
                 IEnumerable<BenchmarkLogicalGroupRule> order = null) =>
                 benchmarksCase
-                    .OrderBy(p => p.Job.Environment.Runtime.Name)
-                    .ThenBy(p => p.Job.Environment.EnvironmentVariables?.FirstOrDefault(
-                        q => q.Key == PgoColumn.PgoEnvironmentVariableName)?.Value ?? "0")
+                    .OrderBy(p => p.Job.Environment.Runtime.MsBuildMoniker)
+                    .ThenBy(p => PgoColumn.IsPgo(p) ? 1 : 0)
                     .ThenBy(p => p.DisplayInfo)
                     .ThenBy(p => !p.Descriptor.Baseline);
 
@@ -65,7 +64,7 @@ namespace Snappier.Benchmarks.Configuration
 
             public string GetLogicalGroupKey(ImmutableArray<BenchmarkCase> allBenchmarksCases,
                 BenchmarkCase benchmarkCase) =>
-                $"{benchmarkCase.Job.Environment.Runtime.Name}-Pgo={(PgoColumn.IsPgo(benchmarkCase) ? "Y" : "N")}";
+                $"{benchmarkCase.Job.Environment.Runtime.MsBuildMoniker}-Pgo={(PgoColumn.IsPgo(benchmarkCase) ? "Y" : "N")}";
 
             public IEnumerable<IGrouping<string, BenchmarkCase>> GetLogicalGroupOrder(
                 IEnumerable<IGrouping<string, BenchmarkCase>> logicalGroups,


### PR DESCRIPTION
Motivation
----------
The BlockCompressHtml benchmark doesn't use the full file. The BlockDecompresHtml benchmark is best to use a 65KB block, but it isn't including the cost of moving the data to the output.

Modifications
-------------
Use the full HTML fill for block compression, and copy the decompressed data to output for decompression.

Make a few more improvements to the version comparison config.