### PR TITLE
Improve speed of hash table clear

### DIFF
--- a/Snappier.Benchmarks/GetHashTable.cs
+++ b/Snappier.Benchmarks/GetHashTable.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+
+namespace Snappier.Benchmarks
+{
+    public class HashTable
+    {
+        private Snappier.Internal.HashTable _hashTable = new();
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _hashTable = new Snappier.Internal.HashTable();
+            _hashTable.EnsureCapacity(65536);
+        }
+
+        [Benchmark]
+        public Span<ushort> GetHashTable()
+        {
+            return _hashTable.GetHashTable(65536);
+        }
+    }
+}

--- a/Snappier/Internal/HashTable.cs
+++ b/Snappier/Internal/HashTable.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using System.Runtime.InteropServices;
 
 namespace Snappier.Internal
 {
@@ -42,8 +43,8 @@ namespace Snappier.Internal
                 ThrowHelper.ThrowInvalidOperationException("Insufficient buffer size");
             }
 
-            var hashTable = _buffer.AsSpan(0, hashTableSize);
-            hashTable.Fill(0);
+            Span<ushort> hashTable = _buffer.AsSpan(0, hashTableSize);
+            MemoryMarshal.AsBytes(hashTable).Fill(0);
 
             return hashTable;
         }


### PR DESCRIPTION
Motivation
----------
Because the hash table is `Span<ushort>` it has some additional overhead when filling with zeroes.

Modifications
-------------
Cast the table to a `Span<byte>` to get a higher performance fill.

Results
-------
BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22000.1455/21H2) Intel Core i7-10850H CPU 2.70GHz, 1 CPU, 12 logical and 6 physical cores .NET SDK=7.0.102
  [Host]     : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  Job-OIYHKP : .NET Framework 4.8 (4.8.4515.0), X64 RyuJIT VectorSize=256
  Job-ZZBQVB : .NET Framework 4.8 (4.8.4515.0), X64 RyuJIT VectorSize=256
  Job-WPSOUO : .NET 6.0.13 (6.0.1322.58009), X64 RyuJIT AVX2
  Job-YZLOYJ : .NET 6.0.13 (6.0.1322.58009), X64 RyuJIT AVX2
  Job-EWEGZB : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  Job-UQUVRQ : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  Job-MBDCRF : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  Job-XMJXHZ : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2

|       Method |            Runtime | BuildConfiguration | PGO |       Mean |    Error |   StdDev | Ratio | RatioSD | Rank |
|------------- |------------------- |------------------- |---- |-----------:|---------:|---------:|------:|--------:|-----:|
| GetHashTable | .NET Framework 4.8 |           Previous |   N | 4,248.9 ns | 83.55 ns | 85.80 ns |  1.00 |    0.00 |    2 |
| GetHashTable | .NET Framework 4.8 |            Default |   N |   992.6 ns | 14.77 ns | 13.09 ns |  0.23 |    0.01 |    1 |
|              |                    |                    |     |            |          |          |       |         |      |
| GetHashTable |           .NET 6.0 |           Previous |   N |   359.0 ns |  7.14 ns |  8.22 ns |  1.00 |    0.00 |    2 |
| GetHashTable |           .NET 6.0 |            Default |   N |   261.4 ns |  2.31 ns |  3.73 ns |  0.73 |    0.02 |    1 |
|              |                    |                    |     |            |          |          |       |         |      |
| GetHashTable |           .NET 7.0 |           Previous |   N |   500.6 ns |  2.45 ns |  2.18 ns |  1.00 |    0.00 |    2 |
| GetHashTable |           .NET 7.0 |            Default |   N |   361.8 ns |  6.35 ns |  4.96 ns |  0.72 |    0.01 |    1 |
|              |                    |                    |     |            |          |          |       |         |      |
| GetHashTable |           .NET 7.0 |           Previous |   Y |   468.9 ns |  4.13 ns |  3.66 ns |  1.00 |    0.00 |    2 |
| GetHashTable |           .NET 7.0 |            Default |   Y |   354.5 ns |  2.49 ns |  2.08 ns |  0.76 |    0.01 |    1 |