### PR TITLE
Simplify PSHUFB copy logic for .NET 6/7

### DIFF
--- a/Snappier.Benchmarks/Configuration/FrameworkCompareConfig.cs
+++ b/Snappier.Benchmarks/Configuration/FrameworkCompareConfig.cs
@@ -1,4 +1,5 @@
 ﻿using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 
@@ -16,6 +17,8 @@ namespace Snappier.Benchmarks.Configuration
             var job70 = baseJob.WithRuntime(CoreRuntime.Core70);
             AddJob(job70);
             AddJob(job70.WithPgo());
+
+            AddLogicalGroupRules(BenchmarkLogicalGroupRule.ByJob);
 
             AddColumn(PgoColumn.Default);
             HideColumns(Column.EnvironmentVariables);


### PR DESCRIPTION
Motivation
----------
There are some simplification that may have marginal perf benefits.

Modifications
-------------
- Drop the intermediate method for adding Vector128.LoadUnsafe for .NET 6.
- Use Vector128.StoreUnsafe on .NET 7.
- Pad the pattern array with an empty vector so we can drop the `patternSize - 1` and just use `patternSize` directly when indexing.