### PR TITLE
Use CRC32 hash when available during compression

### DIFF
--- a/Snappier/Internal/HashTable.cs
+++ b/Snappier/Internal/HashTable.cs
@@ -1,6 +1,12 @@
 ﻿using System;
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+
+#if NET6_0_OR_GREATER
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+#endif
 
 namespace Snappier.Internal
 {
@@ -71,6 +77,52 @@ namespace Snappier.Internal
                 ArrayPool<ushort>.Shared.Return(_buffer);
                 _buffer = null;
             }
+        }
+
+        /// <summary>
+        /// Given a table of uint16_t whose size is mask / 2 + 1, return a pointer to the
+        /// relevant entry, if any, for the given bytes.  Any hash function will do,
+        /// but a good hash function reduces the number of collisions and thus yields
+        /// better compression for compressible input.
+        ///
+        /// REQUIRES: mask is 2 * (table_size - 1), and table_size is a power of two.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref ushort TableEntry(ref ushort table, uint bytes, uint mask)
+        {
+            // Our choice is quicker-and-dirtier than the typical hash function;
+            // empirically, that seems beneficial.  The upper bits of kMagic * bytes are a
+            // higher-quality hash than the lower bits, so when using kMagic * bytes we
+            // also shift right to get a higher-quality end result.  There's no similar
+            // issue with a CRC because all of the output bits of a CRC are equally good
+            // "hashes." So, a CPU instruction for CRC, if available, tends to be a good
+            // choice.
+
+            uint hash;
+
+#if NET6_0_OR_GREATER
+            // We use mask as the second arg to the CRC function, as it's about to
+            // be used anyway; it'd be equally correct to use 0 or some constant.
+            // Mathematically, _mm_crc32_u32 (or similar) is a function of the
+            // xor of its arguments.
+
+            if (System.Runtime.Intrinsics.X86.Sse42.IsSupported)
+            {
+                hash = Sse42.Crc32(bytes, mask);
+
+            }
+            else if (System.Runtime.Intrinsics.Arm.Crc32.IsSupported)
+            {
+                hash = Crc32.ComputeCrc32C(bytes, mask);
+            }
+            else
+#endif
+            {
+                const uint kMagic = 0x1e35a7bd;
+                hash = (kMagic * bytes) >> (31 - MaxHashTableBits);
+            }
+
+            return ref Unsafe.AddByteOffset(ref table, hash & mask);
         }
     }
 }

--- a/Snappier/Internal/Helpers.cs
+++ b/Snappier/Internal/Helpers.cs
@@ -11,17 +11,6 @@ namespace Snappier.Internal
 {
     internal static class Helpers
     {
-        private const uint HashMultiplier = 0x1e35a7bd;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int HashBytes(uint bytes, int shift)
-        {
-            unchecked
-            {
-                return (int)((bytes * HashMultiplier) >> shift);
-            }
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int MaxCompressedLength(int sourceBytes)
         {

--- a/Snappier/Internal/SnappyCompressor.cs
+++ b/Snappier/Internal/SnappyCompressor.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 
 namespace Snappier.Internal
 {
-    internal class SnappyCompressor2 : IDisposable
+    internal class SnappyCompressor : IDisposable
     {
         private HashTable? _workingMemory = new();
 

--- a/Snappier/Internal/SnappyCompressor.cs
+++ b/Snappier/Internal/SnappyCompressor.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 
 namespace Snappier.Internal
 {
-    internal class SnappyCompressor : IDisposable
+    internal class SnappyCompressor2 : IDisposable
     {
         private HashTable? _workingMemory = new();
 
@@ -122,9 +122,7 @@ namespace Snappier.Internal
                 Debug.Assert(input.Length <= Constants.BlockSize);
                 Debug.Assert((tableSpan.Length & (tableSpan.Length - 1)) == 0); // table must be power of two
 
-                int shift = 32 - Helpers.Log2Floor((uint) tableSpan.Length);
-
-                Debug.Assert(uint.MaxValue >> shift == tableSpan.Length - 1);
+                uint mask = (uint)(2 * (tableSpan.Length - 1));
 
                 ref byte inputStart = ref Unsafe.AsRef(in input[0]);
                 // Last byte of the input, not one byte past the end, to avoid issues on GC moves
@@ -183,11 +181,11 @@ namespace Snappier.Internal
 
                                 uint dword = j == 0 ? preload : (uint) data;
                                 Debug.Assert(dword == Helpers.UnsafeReadUInt32(ref Unsafe.Add(ref ip, j)));
-                                int hash = Helpers.HashBytes(dword, shift);
-                                candidate = ref Unsafe.Add(ref inputStart, Unsafe.Add(ref table, hash));
+                                ref ushort tableEntry = ref HashTable.TableEntry(ref table, dword, mask);
+                                candidate = ref Unsafe.Add(ref inputStart, tableEntry);
                                 Debug.Assert(!Unsafe.IsAddressLessThan(ref candidate, ref inputStart));
                                 Debug.Assert(Unsafe.IsAddressLessThan(ref candidate, ref Unsafe.Add(ref ip, j)));
-                                Unsafe.Add(ref table, hash) = (ushort) (delta + j);
+                                tableEntry = (ushort) (delta + j);
 
                                 if (Helpers.UnsafeReadUInt32(ref candidate) == dword)
                                 {
@@ -201,11 +199,11 @@ namespace Snappier.Internal
                                 int i1 = j + 1;
                                 dword = (uint)(data >> 8);
                                 Debug.Assert(dword == Helpers.UnsafeReadUInt32(ref Unsafe.Add(ref ip, i1)));
-                                hash = Helpers.HashBytes(dword, shift);
-                                candidate = ref Unsafe.Add(ref inputStart, Unsafe.Add(ref table, hash));
+                                tableEntry = ref HashTable.TableEntry(ref table, dword, mask);
+                                candidate = ref Unsafe.Add(ref inputStart, tableEntry);
                                 Debug.Assert(!Unsafe.IsAddressLessThan(ref candidate, ref inputStart));
                                 Debug.Assert(Unsafe.IsAddressLessThan(ref candidate, ref Unsafe.Add(ref ip, i1)));
-                                Unsafe.Add(ref table, hash) = (ushort) (delta + i1);
+                                tableEntry = (ushort) (delta + i1);
 
                                 if (Helpers.UnsafeReadUInt32(ref candidate) == dword)
                                 {
@@ -219,11 +217,11 @@ namespace Snappier.Internal
                                 int i2 = j + 2;
                                 dword = (uint)(data >> 16);
                                 Debug.Assert(dword == Helpers.UnsafeReadUInt32(ref Unsafe.Add(ref ip, i2)));
-                                hash = Helpers.HashBytes(dword, shift);
-                                candidate = ref Unsafe.Add(ref inputStart, Unsafe.Add(ref table, hash));
+                                tableEntry = ref HashTable.TableEntry(ref table, dword, mask);
+                                candidate = ref Unsafe.Add(ref inputStart, tableEntry);
                                 Debug.Assert(!Unsafe.IsAddressLessThan(ref candidate, ref inputStart));
                                 Debug.Assert(Unsafe.IsAddressLessThan(ref candidate, ref Unsafe.Add(ref ip, i2)));
-                                Unsafe.Add(ref table, hash) = (ushort) (delta + i2);
+                                tableEntry = (ushort) (delta + i2);
 
                                 if (Helpers.UnsafeReadUInt32(ref candidate) == dword)
                                 {
@@ -237,11 +235,11 @@ namespace Snappier.Internal
                                 int i3 = j + 3;
                                 dword = (uint)(data >> 24);
                                 Debug.Assert(dword == Helpers.UnsafeReadUInt32(ref Unsafe.Add(ref ip, i3)));
-                                hash = Helpers.HashBytes(dword, shift);
-                                candidate = ref Unsafe.Add(ref inputStart, Unsafe.Add(ref table, hash));
+                                tableEntry = ref HashTable.TableEntry(ref table, dword, mask);
+                                candidate = ref Unsafe.Add(ref inputStart, tableEntry);
                                 Debug.Assert(!Unsafe.IsAddressLessThan(ref candidate, ref inputStart));
                                 Debug.Assert(Unsafe.IsAddressLessThan(ref candidate, ref Unsafe.Add(ref ip, i3)));
-                                Unsafe.Add(ref table, hash) = (ushort) (delta + i3);
+                                tableEntry = (ushort) (delta + i3);
 
                                 if (Helpers.UnsafeReadUInt32(ref candidate) == dword)
                                 {
@@ -262,7 +260,7 @@ namespace Snappier.Internal
                         while (true)
                         {
                             Debug.Assert((uint) data == Helpers.UnsafeReadUInt32(ref ip));
-                            int hash = Helpers.HashBytes((uint) data, shift);
+                            ref ushort tableEntry = ref HashTable.TableEntry(ref table, (uint) data, mask);
                             int bytesBetweenHashLookups = skip >> 5;
                             skip += bytesBetweenHashLookups;
 
@@ -273,11 +271,11 @@ namespace Snappier.Internal
                                 goto emit_remainder;
                             }
 
-                            candidate = ref Unsafe.Add(ref inputStart, Unsafe.Add(ref table, hash));
+                            candidate = ref Unsafe.Add(ref inputStart, tableEntry);
                             Debug.Assert(!Unsafe.IsAddressLessThan(ref candidate, ref inputStart));
                             Debug.Assert(Unsafe.IsAddressLessThan(ref candidate, ref ip));
 
-                            Unsafe.Add(ref table, hash) = (ushort) Unsafe.ByteOffset(ref inputStart, ref ip);
+                            tableEntry = (ushort) Unsafe.ByteOffset(ref inputStart, ref ip);
                             if ((uint) data == Helpers.UnsafeReadUInt32(ref candidate))
                             {
                                 break;
@@ -335,13 +333,13 @@ namespace Snappier.Internal
                                          (Helpers.UnsafeReadUInt64(ref ip) & 0xfffffffffful));
 
                             // We are now looking for a 4-byte match again.  We read
-                            // table[Hash(ip, shift)] for that.  To improve compression,
-                            // we also update table[Hash(ip - 1, shift)] and table[Hash(ip, shift)].
-                            Unsafe.Add(ref table, Helpers.HashBytes(Helpers.UnsafeReadUInt32(ref Unsafe.Subtract(ref ip, 1)), shift)) =
+                            // table[Hash(ip, mask)] for that.  To improve compression,
+                            // we also update table[Hash(ip - 1, mask)] and table[Hash(ip, mask)].
+                            HashTable.TableEntry(ref table, Helpers.UnsafeReadUInt32(ref Unsafe.Subtract(ref ip, 1)), mask) =
                                 (ushort) (Unsafe.ByteOffset(ref inputStart, ref ip) - 1);
-                            int hash = Helpers.HashBytes((uint) data, shift);
-                            candidate = ref Unsafe.Add(ref inputStart, Unsafe.Add(ref table, hash));
-                            Unsafe.Add(ref table, hash) = (ushort) Unsafe.ByteOffset(ref inputStart, ref ip);
+                            ref ushort tableEntry = ref HashTable.TableEntry(ref table, (uint) data, mask);
+                            candidate = ref Unsafe.Add(ref inputStart, tableEntry);
+                            tableEntry = (ushort) Unsafe.ByteOffset(ref inputStart, ref ip);
                         } while ((uint) data == Helpers.UnsafeReadUInt32(ref candidate));
 
                         // Because the least significant 5 bytes matched, we can utilize data


### PR DESCRIPTION
Motivation
----------
The reference Snappy implementation has switched to this approach to get a performance gain.

Modifications
-------------
When CRC32C intrinsics are available on x86 or ARM use them to index into the hash table. Also rework the hash operations to use a reference to make it faster to write back to the same location after each step.

Results
-------
BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22000.1455/21H2) Intel Core i7-10850H CPU 2.70GHz, 1 CPU, 12 logical and 6 physical cores .NET SDK=7.0.200
  [Host]     : .NET 7.0.3 (7.0.323.6910), X64 RyuJIT AVX2
  Job-NOAZVY : .NET 7.0.3 (7.0.323.6910), X64 RyuJIT AVX2
  Job-WNHWWN : .NET 6.0.14 (6.0.1423.7309), X64 RyuJIT AVX2
  Job-MXBHYC : .NET 7.0.3 (7.0.323.6910), X64 RyuJIT AVX2
  Job-AZKGJL : .NET Framework 4.8 (4.8.4614.0), X64 RyuJIT VectorSize=256

| Method |            Runtime | PGO |     Mean |   Error |  StdDev |   Median | Ratio | RatioSD | Rank |
|------- |------------------- |---- |---------:|--------:|--------:|---------:|------:|--------:|-----:|
| Legacy |           .NET 7.0 |   Y | 112.9 us | 1.93 us | 1.81 us | 113.1 us |  1.00 |    0.00 |    2 |
|    New |           .NET 7.0 |   Y | 109.6 us | 0.20 us | 0.16 us | 109.6 us |  0.97 |    0.02 |    1 |
|        |                    |     |          |         |         |          |       |         |      |
| Legacy |           .NET 6.0 |   N | 121.8 us | 2.42 us | 2.89 us | 120.7 us |  1.00 |    0.00 |    2 |
|    New |           .NET 6.0 |   N | 117.2 us | 2.30 us | 2.56 us | 118.2 us |  0.96 |    0.04 |    1 |
|        |                    |     |          |         |         |          |       |         |      |
| Legacy |           .NET 7.0 |   N | 118.3 us | 2.36 us | 2.62 us | 116.4 us |  1.00 |    0.00 |    1 |
|    New |           .NET 7.0 |   N | 116.5 us | 0.18 us | 0.15 us | 116.5 us |  0.99 |    0.02 |    1 |
|        |                    |     |          |         |         |          |       |         |      |
| Legacy | .NET Framework 4.8 |   N | 210.6 us | 4.15 us | 5.40 us | 210.0 us |  1.00 |    0.00 |    1 |
|    New | .NET Framework 4.8 |   N | 211.5 us | 3.94 us | 4.05 us | 213.2 us |  1.00 |    0.03 |    1 |