### PR TITLE
Remove some unnecessary unsafe blocks

### DIFF
--- a/Snappier.Benchmarks/FindMatchLength.cs
+++ b/Snappier.Benchmarks/FindMatchLength.cs
@@ -13,7 +13,7 @@ namespace Snappier.Benchmarks
         };
 
         [Benchmark(Baseline = true)]
-        public unsafe (long, bool) Regular()
+        public (long, bool) Regular()
         {
             ulong data = 0;
 

--- a/Snappier.Benchmarks/Snappier.Benchmarks.csproj
+++ b/Snappier.Benchmarks/Snappier.Benchmarks.csproj
@@ -6,7 +6,6 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
 
     <IsPackable>false</IsPackable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>11</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Snappier.snk</AssemblyOriginatorKeyFile>

--- a/Snappier.Tests/Internal/SnappyCompressorTests.cs
+++ b/Snappier.Tests/Internal/SnappyCompressorTests.cs
@@ -82,7 +82,7 @@ namespace Snappier.Tests.Internal
         [InlineData(11, "xxxxxxabcd0123", "xxxxxxabcd0?23", 14)]
         [InlineData(12, "xxxxxxabcd0123", "xxxxxxabcd0132", 14)]
         [InlineData(13, "xxxxxxabcd0123", "xxxxxxabcd012?", 14)]
-        public unsafe void FindMatchLength(int expectedResult, string s1String, string s2String, int length)
+        public void FindMatchLength(int expectedResult, string s1String, string s2String, int length)
         {
             var array = Encoding.ASCII.GetBytes(s1String + s2String
                                                          + new string('\0', Math.Max(0, length - s2String.Length)));

--- a/Snappier.Tests/Snappier.Tests.csproj
+++ b/Snappier.Tests/Snappier.Tests.csproj
@@ -5,7 +5,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net48</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>11</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Snappier.snk</AssemblyOriginatorKeyFile>

--- a/Snappier/Internal/CopyHelpers.cs
+++ b/Snappier/Internal/CopyHelpers.cs
@@ -47,11 +47,7 @@ namespace Snappier.Internal
         /// <param name="opEnd">Pointer to the end of the area to write in the buffer.</param>
         /// <param name="bufferEnd">Pointer past the end of the buffer.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static
-#if NET6_0
-            unsafe
-#endif
-            void IncrementalCopy(ref byte source, ref byte op, ref byte opEnd, ref byte bufferEnd)
+        public static void IncrementalCopy(ref byte source, ref byte op, ref byte opEnd, ref byte bufferEnd)
         {
             Debug.Assert(Unsafe.IsAddressLessThan(ref source, ref op));
             Debug.Assert(!Unsafe.IsAddressGreaterThan(ref op, ref opEnd));
@@ -107,11 +103,7 @@ namespace Snappier.Internal
 
                         while (Unsafe.IsAddressLessThan(ref op, ref loopEnd))
                         {
-#if NET7_0_OR_GREATER
                             pattern.StoreUnsafe(ref op);
-#else
-                            Store((byte*)Unsafe.AsPointer(ref op), pattern);
-#endif
                             op = ref Unsafe.Add(ref op, patternSize);
                         }
 
@@ -219,7 +211,7 @@ namespace Snappier.Internal
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe void IncrementalCopySlow(ref byte source, ref byte op, ref byte opEnd)
+        public static void IncrementalCopySlow(ref byte source, ref byte op, ref byte opEnd)
         {
             while (Unsafe.IsAddressLessThan(ref op, ref opEnd))
             {

--- a/Snappier/Internal/Helpers.cs
+++ b/Snappier/Internal/Helpers.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 #if NET6_0_OR_GREATER
 using System.Numerics;
+using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
 
@@ -109,6 +110,21 @@ namespace Snappier.Internal
 
             Unsafe.WriteUnaligned(ref ptr, value);
         }
+
+#if NET6_0
+
+        // Port of the method from .NET 7, but specific to bytes
+
+        /// <summary>Stores a vector at the given destination.</summary>
+        /// <param name="source">The vector that will be stored.</param>
+        /// <param name="destination">The destination at which <paramref name="source" /> will be stored.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void StoreUnsafe(this Vector128<byte> source, ref byte destination)
+        {
+            Unsafe.WriteUnaligned(ref destination, source);
+        }
+
+#endif
 
         /// <summary>
         /// Return floor(log2(n)) for positive integer n.  Returns -1 iff n == 0.

--- a/Snappier/Internal/SnappyDecompressor.cs
+++ b/Snappier/Internal/SnappyDecompressor.cs
@@ -176,7 +176,7 @@ namespace Snappier.Internal
             return result;
         }
 
-        internal unsafe void DecompressAllTags(ReadOnlySpan<byte> inputSpan)
+        internal void DecompressAllTags(ReadOnlySpan<byte> inputSpan)
         {
             // Put Constants.CharTable on the stack to simplify lookups within the loops below.
             // Slicing with length 256 here allows the JIT compiler to recognize the size is greater than

--- a/Snappier/Snappier.csproj
+++ b/Snappier/Snappier.csproj
@@ -5,7 +5,6 @@
 
     <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Snappier.snk</AssemblyOriginatorKeyFile>
 


### PR DESCRIPTION
Motivation
----------
General cleanup.

Modifications
-------------
Remove unsafe code blocks where we no longer need them. Port one method from .NET 7 to .NET 6 to remove the last use of a pointer.