### PR TITLE
Improve Log2Floor for legacy runtimes

### DIFF
--- a/Snappier.Benchmarks/Configuration/VersionComparisonConfig.cs
+++ b/Snappier.Benchmarks/Configuration/VersionComparisonConfig.cs
@@ -41,7 +41,7 @@ namespace Snappier.Benchmarks.Configuration
             WithOrderer(VersionComparisonOrderer.Default);
 
             AddColumn(PgoColumn.Default);
-            HideColumns(Column.EnvironmentVariables);
+            HideColumns(Column.EnvironmentVariables, Column.Job);
         }
 
         private class VersionComparisonOrderer : IOrderer

--- a/Snappier.Benchmarks/Log2Floor.cs
+++ b/Snappier.Benchmarks/Log2Floor.cs
@@ -1,0 +1,17 @@
+﻿using BenchmarkDotNet.Attributes;
+using Snappier.Internal;
+
+namespace Snappier.Benchmarks
+{
+    [DisassemblyDiagnoser(2)]
+    public class Log2FloorHelper
+    {
+        private uint _n = 5;
+
+        [Benchmark]
+        public int Log2Floor()
+        {
+            return Helpers.Log2Floor(_n);
+        }
+    }
+}

--- a/Snappier/Internal/Helpers.cs
+++ b/Snappier/Internal/Helpers.cs
@@ -2,6 +2,7 @@
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 #if NET6_0_OR_GREATER
 using System.Numerics;
 using System.Runtime.Intrinsics;
@@ -126,8 +127,50 @@ namespace Snappier.Internal
 
 #endif
 
+#if !NET6_0_OR_GREATER
+
+        // Port from .NET 7 BitOperations of a faster fallback algorithm for .NET Standard since we don't have intrinsics
+        // or BitOperations. This is the same algorithm used by BitOperations.Log2 when hardware acceleration is unavailable.
+        // https://github.com/dotnet/runtime/blob/bee217ffbdd6b3ad60b0e1e17c6370f4bb618779/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs#L404
+
+        private static ReadOnlySpan<byte> Log2DeBruijn => new byte[32]
+        {
+            00, 09, 01, 10, 13, 21, 02, 29,
+            11, 14, 16, 18, 22, 25, 03, 30,
+            08, 12, 20, 28, 15, 17, 24, 07,
+            19, 27, 23, 06, 26, 05, 04, 31
+        };
+
         /// <summary>
-        /// Return floor(log2(n)) for positive integer n.  Returns -1 iff n == 0.
+        /// Returns the integer (floor) log of the specified value, base 2.
+        /// Note that by convention, input value 0 returns 0 since Log(0) is undefined.
+        /// Does not directly use any hardware intrinsics, nor does it incur branching.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        private static int Log2SoftwareFallback(uint value)
+        {
+            // No AggressiveInlining due to large method size
+            // Has conventional contract 0->0 (Log(0) is undefined)
+
+            // Fill trailing zeros with ones, eg 00010010 becomes 00011111
+            value |= value >> 01;
+            value |= value >> 02;
+            value |= value >> 04;
+            value |= value >> 08;
+            value |= value >> 16;
+
+            // uint.MaxValue >> 27 is always in range [0 - 31] so we use Unsafe.AddByteOffset to avoid bounds check
+            return Unsafe.AddByteOffset(
+                // Using deBruijn sequence, k=2, n=5 (2^5=32) : 0b_0000_0111_1100_0100_1010_1100_1101_1101u
+                ref MemoryMarshal.GetReference(Log2DeBruijn),
+                // uint|long -> IntPtr cast on 32-bit platforms does expensive overflow checks not needed here
+                (IntPtr)(int)((value * 0x07C4ACDDu) >> 27));
+        }
+
+#endif
+
+        /// <summary>
+        /// Return floor(log2(n)) for positive integer n.  Returns -1 if n == 0.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Log2Floor(uint n) =>
@@ -145,7 +188,7 @@ namespace Snappier.Internal
 #if NET6_0_OR_GREATER
             return BitOperations.Log2(n);
 #else
-            return (int) Math.Floor(Math.Log(n, 2));
+            return Log2SoftwareFallback(n);
 #endif
         }
 


### PR DESCRIPTION
Motivation
----------
There are more performant algorithms for Log2Floor available for legacy runtimes where BitOperations and intrinsics are not available.

Modifications
-------------
Port the fallback used by BitOperations.Log2 when hardware acceleration is not available.

Results
-------
BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22000.1641/21H2) Intel Core i7-10850H CPU 2.70GHz, 1 CPU, 12 logical and 6 physical cores .NET SDK=7.0.200
  [Host]     : .NET 7.0.3 (7.0.323.6910), X64 RyuJIT AVX2
  Job-DYBDUA : .NET Framework 4.8 (4.8.4614.0), X64 RyuJIT VectorSize=256
  Job-UUNMHF : .NET Framework 4.8 (4.8.4614.0), X64 RyuJIT VectorSize=256

EnvironmentVariables=Empty  Runtime=.NET Framework 4.8

|    Method | BuildConfiguration |      Mean |     Error |    StdDev | Ratio | Rank | Code Size |
|---------- |------------------- |----------:|----------:|----------:|------:|-----:|----------:|
| Log2Floor |           Previous | 18.661 ns | 0.0988 ns | 0.0876 ns |  1.00 |    2 |     282 B |
| Log2Floor |            Default |  9.521 ns | 0.0515 ns | 0.0402 ns |  0.51 |    1 |     180 B |

This should consequently provide a small boost to compression speed on legacy frameworks, primarily when writing large literals > 60 bytes.