### PR TITLE
Simplify stream decompress logic

### DIFF
--- a/Snappier.Benchmarks/BlockCompressHtml.cs
+++ b/Snappier.Benchmarks/BlockCompressHtml.cs
@@ -15,7 +15,7 @@ namespace Snappier.Benchmarks
             using var resource =
                 typeof(BlockCompressHtml).Assembly.GetManifestResourceStream("Snappier.Benchmarks.TestData.html");
 
-            byte[] input = new byte[resource!.Length];
+            byte[] input = new byte[65536]; // Just test the first 64KB
             int inputLength = resource!.Read(input, 0, input.Length);
             _input = input.AsMemory(0, inputLength);
 

--- a/Snappier.Benchmarks/Configuration/VersionComparisonConfig.cs
+++ b/Snappier.Benchmarks/Configuration/VersionComparisonConfig.cs
@@ -64,7 +64,7 @@ namespace Snappier.Benchmarks.Configuration
 
             public string GetLogicalGroupKey(ImmutableArray<BenchmarkCase> allBenchmarksCases,
                 BenchmarkCase benchmarkCase) =>
-                $"{benchmarkCase.Job.Environment.Runtime.MsBuildMoniker}-Pgo={(PgoColumn.IsPgo(benchmarkCase) ? "Y" : "N")}";
+                $"{benchmarkCase.Job.Environment.Runtime.MsBuildMoniker}-Pgo={(PgoColumn.IsPgo(benchmarkCase) ? "Y" : "N")}-{benchmarkCase.Descriptor.MethodIndex}";
 
             public IEnumerable<IGrouping<string, BenchmarkCase>> GetLogicalGroupOrder(
                 IEnumerable<IGrouping<string, BenchmarkCase>> logicalGroups,

--- a/Snappier.Benchmarks/Overview.cs
+++ b/Snappier.Benchmarks/Overview.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using BenchmarkDotNet.Attributes;
+using Snappier.Internal;
+
+namespace Snappier.Benchmarks
+{
+    public class Overview
+    {
+        private MemoryStream _htmlStream;
+        private Memory<byte> _htmlMemory;
+
+        private ReadOnlyMemory<byte> _compressed;
+        private MemoryStream _compressedStream;
+
+        private Memory<byte> _outputBuffer;
+        private byte[] _streamOutputBuffer;
+        private MemoryStream _streamOutput;
+
+        [GlobalSetup]
+        public void LoadToMemory()
+        {
+            _htmlStream = new MemoryStream();
+            using var resource =
+                typeof(DecompressHtml).Assembly.GetManifestResourceStream("Snappier.Benchmarks.TestData.html");
+            resource!.CopyTo(_htmlStream);
+            _htmlStream.Position = 0;
+
+            byte[] input = new byte[65536]; // Just test the first 64KB
+            // ReSharper disable once PossibleNullReferenceException
+            int inputLength = _htmlStream.Read(input, 0, input.Length);
+            _htmlMemory = input.AsMemory(0, inputLength);
+
+            byte[] compressed = new byte[Snappy.GetMaxCompressedLength(inputLength)];
+            int compressedLength = Snappy.Compress(_htmlMemory.Span, compressed);
+
+            _compressed = compressed.AsMemory(0, compressedLength);
+
+            _compressedStream = new MemoryStream();
+            using var resource2 =
+                typeof(DecompressHtml).Assembly.GetManifestResourceStream("Snappier.Benchmarks.TestData.html_x_4.snappy");
+            // ReSharper disable once PossibleNullReferenceException
+            resource2.CopyTo(_compressedStream);
+
+            _outputBuffer = new byte[Snappy.GetMaxCompressedLength(inputLength)];
+            _streamOutputBuffer = new byte[16384];
+            _streamOutput = new MemoryStream();
+        }
+
+        [Benchmark]
+        public int BlockCompress64KbHtml()
+        {
+            using var compressor = new SnappyCompressor();
+
+            return compressor.Compress(_htmlMemory.Span, _outputBuffer.Span);
+        }
+
+        [Benchmark]
+        public void BlockDecompress64KbHtml()
+        {
+            using var decompressor = new SnappyDecompressor();
+
+            decompressor.Decompress(_compressed.Span);
+        }
+
+        [Benchmark]
+        public void StreamCompressHtml()
+        {
+            _htmlStream.Position = 0;
+            _streamOutput.Position = 0;
+            using var stream = new SnappyStream(_streamOutput, CompressionMode.Compress, true);
+
+            _htmlStream.CopyTo(stream, 16384);
+            stream.Flush();
+        }
+
+        [Benchmark]
+        public void StreamDecompressHtml()
+        {
+            _compressedStream.Position = 0;
+            using var stream = new SnappyStream(_compressedStream, CompressionMode.Decompress, true);
+
+            while (stream.Read(_streamOutputBuffer, 0, _streamOutputBuffer.Length) > 0)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
We can get some small gains in stream decompression while also making the logic a bit simpler.

Modifications
-------------
- Drop the local var copies of the class fields, just update the fields directly.
- Replace exceptions with throw helpers
- Optimize the short circuit when we're out of data
- Add an Overview benchmark to provide a release performance overview
- Add an additional grouping by method in VersionComparisonConfig so that it works with Overview
- Make BlockCompressHtml agree with Overview by only compressing 64KB