### PR TITLE
Switch several arrays to static data references

### DIFF
--- a/Snappier/Internal/Helpers.cs
+++ b/Snappier/Internal/Helpers.cs
@@ -45,7 +45,7 @@ namespace Snappier.Internal
             return 32 + sourceBytes + sourceBytes / 6 + 1;
         }
 
-        private static readonly byte[] LeftShiftOverflowsMasks =
+        private static ReadOnlySpan<byte> LeftShiftOverflowsMasks => new byte[]
         {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,


### PR DESCRIPTION
Motivation
----------
Avoid static constructors and allocating static data on the heap.

Modifications
-------------
Where possible, reference static data directly.