### PR TITLE
Allow ref byte to point just past the end of spans

### DIFF
--- a/Snappier.Benchmarks/FindMatchLength.cs
+++ b/Snappier.Benchmarks/FindMatchLength.cs
@@ -64,7 +64,7 @@ namespace Snappier.Benchmarks
 
             ref byte s1 = ref _array[0];
             ref byte s2 = ref Unsafe.Add(ref s1, 12);
-            ref byte s2Limit = ref Unsafe.Add(ref s1, _array.Length - 1);
+            ref byte s2Limit = ref Unsafe.Add(ref s1, _array.Length);
 
             return SnappyCompressor.FindMatchLength(ref s1, ref s2, ref s2Limit, ref data);
         }

--- a/Snappier.Tests/Internal/SnappyCompressorTests.cs
+++ b/Snappier.Tests/Internal/SnappyCompressorTests.cs
@@ -92,7 +92,7 @@ namespace Snappier.Tests.Internal
             ref byte s2 = ref Unsafe.Add(ref s1, s1String.Length);
 
             var result =
-                SnappyCompressor.FindMatchLength(ref s1, ref s2, ref Unsafe.Add(ref s2, length - 1), ref data);
+                SnappyCompressor.FindMatchLength(ref s1, ref s2, ref Unsafe.Add(ref s2, length), ref data);
 
             Assert.Equal(result.matchLength < 8, result.matchLengthLessThan8);
             Assert.Equal(expectedResult, result.matchLength);


### PR DESCRIPTION
Motivation
----------
I was under the impression that `ref byte` should never point past the end of a `Span<byte>` or `ReadOnlySpan<byte>` because then GC couldn't recognize the pointer and adjust it during GC moves. However, this there is a specific exception that allows `ref byte` to point precisely one byte past the end and still be recognized to allow pointer arithmetic scenarios like the ones in this algorithm.

Modifications
-------------
Where there is more complex logic (compared to the reference C++ implementation) to allow buffer end pointers to point to the last byte in the buffer simplify this logic and point one byte past the end of the buffer.

Also ensure that comparison operations that ensure a certain length don't involve an intermediate pointer that moves off the beginning of the buffer.

Results
-------
We're now back to closer to the reference C++ implementation but still have memory safety.