### PR TITLE
check table size greater than

### DIFF
--- a/Snappier/Internal/HashTable.cs
+++ b/Snappier/Internal/HashTable.cs
@@ -25,7 +25,7 @@ namespace Snappier.Internal
             var maxFragmentSize = Math.Min(inputSize, (int) Constants.BlockSize);
             var tableSize = CalculateTableSize(maxFragmentSize);
 
-            if (_buffer is null || tableSize < _buffer.Length)
+            if (_buffer is null || tableSize > _buffer.Length)
             {
                 if (_buffer is not null)
                 {


### PR DESCRIPTION
Check if table size is greater than buffer length, instead of the other way around. 

I run into an exception because i am flushing my compressor, and then write a chunk that is bigger, than what the buffer is can contain.