### PR TITLE
Rework test reporter for public PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,12 +46,11 @@ jobs:
         dotnet test --no-build -f ${{ matrix.framework }} --configuration Release --verbosity normal --logger "trx;LogFileName=results.trx"
 
     - name: Test Report
-      uses: dorny/test-reporter@v1
+      uses: actions/upload-artifact@v3
       if: success() || failure() # run this step even if previous step failed
       with:
-        name: Unit Tests ${{ matrix.framework }} ${{ matrix.disable }}
+        name: test-results-${{ matrix.framework }}-${{ matrix.disable }}
         path: "**/results.trx"
-        reporter: dotnet-trx
 
   test-windows:
 
@@ -79,19 +78,17 @@ jobs:
         dotnet test --runtime win10-x86 -f net48 --configuration Release --verbosity normal --logger "trx;LogFileName=results-x86.trx"
 
     - name: Test Report x64
-      uses: dorny/test-reporter@v1
+      uses: actions/upload-artifact@v3
       if: success() || failure() # run this step even if previous step failed
       with:
-        name: Unit Tests Windows x64
+        name: tests-results-windows-x64
         path: "**/results-x64.trx"
-        reporter: dotnet-trx
     - name: Test Report x86
-      uses: dorny/test-reporter@v1
+      uses: actions/upload-artifact@v3
       if: success() || failure() # run this step even if previous step failed
       with:
-        name: Unit Tests Windows x86
+        name: test-results-windows-x86
         path: "**/results-x86.trx"
-        reporter: dotnet-trx
 
   publish:
 

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,40 @@
+name: 'Test Report'
+on:
+  workflow_run:
+    workflows:
+      - Build
+    types:
+      - completed
+permissions:
+  contents: read
+  actions: read
+  checks: write
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        framework: ["net6.0", "net7.0"]
+        disable: ["HWIntrinsics", "SSSE3", "BMI2", "Noop"]
+    steps:
+    - uses: dorny/test-reporter@v1
+      with:
+        artifact: test-results-${{ matrix.framework }}-${{ matrix.disable }}
+        name: Unit Tests ${{ matrix.framework }} ${{ matrix.disable }}
+        path: '**/results.trx' # Path to test results (inside artifact .zip)
+        reporter: dotnet-trx
+  report-windows:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dorny/test-reporter@v1
+      with:
+        artifact: test-results-windows-x64
+        name: Unit Tests Windows x64
+        path: '**/results-x64.trx' # Path to test results (inside artifact .zip)
+        reporter: dotnet-trx
+    - uses: dorny/test-reporter@v1
+      with:
+        artifact: test-results-windows-x86
+        name: Unit Tests Windows x86
+        path: '**/results-x86.trx' # Path to test results (inside artifact .zip)
+        reporter: dotnet-trx


### PR DESCRIPTION
This allows PRs from forks to succeed and post test results with appropriate security rights.