### PR TITLE
Update to target .NET 8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,8 +74,8 @@ jobs:
       run: dotnet restore
     - name: Test
       run: |-
-        dotnet test --runtime win10-x64 -f net48 --configuration Release --verbosity normal --logger "trx;LogFileName=results-x64.trx"
-        dotnet test --runtime win10-x86 -f net48 --configuration Release --verbosity normal --logger "trx;LogFileName=results-x86.trx"
+        dotnet test --runtime win-x64 -f net48 --configuration Release --verbosity normal --logger "trx;LogFileName=results-x64.trx"
+        dotnet test --runtime win-x86 -f net48 --configuration Release --verbosity normal --logger "trx;LogFileName=results-x86.trx"
 
     - name: Test Report x64
       uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        framework: ["net6.0", "net7.0"]
+        framework: ["net6.0", "net8.0"]
         disable: ["HWIntrinsics", "SSSE3", "BMI2", "Noop"]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET 7
+    - uses: actions/checkout@v4
+    - name: Setup .NET 8
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '8.0.x'
     - name: Setup .NET 6
       if: matrix.framework == 'net6.0'
       uses: actions/setup-dotnet@v3
@@ -57,11 +57,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET 7
+    - uses: actions/checkout@v4
+    - name: Setup .NET 8
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '8.0.x'
     # Cache packages for faster subsequent runs
     - uses: actions/cache@v3
       with:
@@ -99,11 +99,11 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/release/') }}
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET 7
+    - uses: actions/checkout@v4
+    - name: Setup .NET 8
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '8.0.x'
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        framework: ["net6.0", "net7.0"]
+        framework: ["net6.0", "net8.0"]
         disable: ["HWIntrinsics", "SSSE3", "BMI2", "Noop"]
     steps:
     - uses: dorny/test-reporter@v1

--- a/Snappier.Benchmarks/Configuration/FrameworkCompareConfig.cs
+++ b/Snappier.Benchmarks/Configuration/FrameworkCompareConfig.cs
@@ -14,9 +14,9 @@ namespace Snappier.Benchmarks.Configuration
             AddJob(baseJob
                 .WithRuntime(CoreRuntime.Core60));
 
-            var job70 = baseJob.WithRuntime(CoreRuntime.Core70);
-            AddJob(job70);
-            AddJob(job70.WithPgo());
+            var job80 = baseJob.WithRuntime(CoreRuntime.Core80);
+            AddJob(job80.WithPgo(false));
+            AddJob(job80.WithPgo(true));
 
             AddLogicalGroupRules(BenchmarkLogicalGroupRule.ByJob);
 

--- a/Snappier.Benchmarks/Snappier.Benchmarks.csproj
+++ b/Snappier.Benchmarks/Snappier.Benchmarks.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0;net7.0;net8.0</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
 
     <IsPackable>false</IsPackable>
-    <LangVersion>11</LangVersion>
+    <LangVersion>12</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Snappier.snk</AssemblyOriginatorKeyFile>
     <NoWarn>$(NoWarn);8002</NoWarn> <!-- Don't nag about Snappy.NET not being strong named -->
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.4" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.4" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.10" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Snappier.Tests/Snappier.Tests.csproj
+++ b/Snappier.Tests/Snappier.Tests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net48</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
-    <LangVersion>11</LangVersion>
+    <LangVersion>12</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Snappier.snk</AssemblyOriginatorKeyFile>
 
@@ -20,13 +20,13 @@
 
   <ItemGroup>
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Snappier/Internal/CopyHelpers.cs
+++ b/Snappier/Internal/CopyHelpers.cs
@@ -237,14 +237,14 @@ namespace Snappier.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void UnalignedCopy64(in byte source, ref byte destination)
         {
-            long tempStackVar = Unsafe.As<byte, long>(ref Unsafe.AsRef(source));
+            long tempStackVar = Unsafe.As<byte, long>(ref Unsafe.AsRef(in source));
             Unsafe.As<byte, long>(ref destination) = tempStackVar;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void UnalignedCopy128(in byte source, ref byte destination)
         {
-            Guid tempStackVar = Unsafe.As<byte, Guid>(ref Unsafe.AsRef(source));
+            Guid tempStackVar = Unsafe.As<byte, Guid>(ref Unsafe.AsRef(in source));
             Unsafe.As<byte, Guid>(ref destination) = tempStackVar;
         }
     }

--- a/Snappier/Snappier.csproj
+++ b/Snappier/Snappier.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
 
-    <LangVersion>11</LangVersion>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Snappier.snk</AssemblyOriginatorKeyFile>
@@ -40,16 +40,9 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Add a .NET 8 target (leave .NET 7 target for now until it's EOL)
- Remove .NET 7 from unit test runs in CI, add .NET 8
- Use .NET 8 SDK to build and set LangVersion to 12
- Drop SourceLink dependency since it's now baked into the SDK
- Upgrade various dependencies