### PR TITLE
Update README.md - Correcting wrong descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@ public class Program
         // First, compression
         using var compressed = new MemoryStream();
 
-        using (var compressor = new SnappyStream(compressed, CompressionMode.Compress, false)) {
+        using (var compressor = new SnappyStream(compressed, CompressionMode.Compress, true)) {
             await fileStream.CopyToAsync(compressor);
 
             // Disposing the compressor also flushes the buffers to the inner stream
-            // We pass false to the constructor above so that it doesn't dispose the inner stream
+            // We pass true to the constructor above so that it doesn't close/dispose the inner stream
             // Alternatively, we could call compressor.Flush()
         }
 

--- a/Snappier/SnappyStream.cs
+++ b/Snappier/SnappyStream.cs
@@ -51,7 +51,7 @@ namespace Snappier
         /// </summary>
         /// <param name="stream">Source or destination stream.</param>
         /// <param name="mode">Compression or decompression mode.</param>
-        /// <param name="leaveOpen">If true, close the stream when the SnappyStream is closed.</param>
+        /// <param name="leaveOpen">If true, leave the inner stream open when the SnappyStream is closed.</param>
         /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
         /// <exception cref="ArgumentException">Stream read/write capability doesn't match with <paramref name="mode"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Invalid <paramref name="mode"/>.</exception>


### PR DESCRIPTION
Correcting wrong descriptions 
The `leaveOpen` means don't close/dispose the inner stream when closing/disposing.