### PR TITLE
Use VarIntEncoding.TryRead in SnappyDecompressor

### DIFF
--- a/Snappier.Benchmarks/Snappier.Benchmarks.csproj
+++ b/Snappier.Benchmarks/Snappier.Benchmarks.csproj
@@ -43,6 +43,8 @@
     <Compile Remove="FindMatchLength.cs" />
     <Compile Remove="IncrementalCopy.cs" />
     <Compile Remove="Unaligned*.cs" />
+    <Compile Remove="Internal\VarIntEncodingReadTests.cs" />
+    <Compile Remove="Internal\VarIntEncodingWriteTests.cs" />
   </ItemGroup>
 
 </Project>

--- a/Snappier.Tests/Internal/SnappyDecompressorTests.cs
+++ b/Snappier.Tests/Internal/SnappyDecompressorTests.cs
@@ -7,6 +7,38 @@ namespace Snappier.Tests.Internal
 {
     public class SnappyDecompressorTests
     {
+        #region Decompress
+
+        [Fact]
+        public void Decompress_SplitLength_Succeeds()
+        {
+            // Arrange
+
+            using var decompressor = new SnappyDecompressor();
+
+            // Requires 3 bytes to varint encode the length
+            var data = new byte[65536];
+            using var compressed = Snappy.CompressToMemory(data);
+
+            // Act
+
+            decompressor.Decompress(compressed.Memory.Span.Slice(0, 1));
+            Assert.True(decompressor.NeedMoreData);
+            decompressor.Decompress(compressed.Memory.Span.Slice(1, 1));
+            Assert.True(decompressor.NeedMoreData);
+            decompressor.Decompress(compressed.Memory.Span.Slice(2));
+            Assert.False(decompressor.NeedMoreData);
+
+            using var result = decompressor.ExtractData();
+
+            // Assert
+
+            Assert.Equal(65536, result.Memory.Length);
+            Assert.True(result.Memory.Span.SequenceEqual(data));
+        }
+
+        #endregion
+
         #region DecompressAllTags
 
         [Fact]


### PR DESCRIPTION
Simplified code and shows improved performance on streaming decompression for modern frameworks.

BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.2314) Unknown processor
.NET SDK 9.0.100
  [Host]     : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
  Job-SXYOZE : .NET Framework 4.8.1 (4.8.9282.0), X64 RyuJIT VectorSize=256
  Job-YZRTRU : .NET Framework 4.8.1 (4.8.9282.0), X64 RyuJIT VectorSize=256
  Job-LUMTGV : .NET 6.0.36 (6.0.3624.51421), X64 RyuJIT AVX2
  Job-WIRWZO : .NET 6.0.36 (6.0.3624.51421), X64 RyuJIT AVX2
  Job-CCWZUZ : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2
  Job-JRBCAZ : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2
  Job-AXYWAW : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
  Job-RYXATQ : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2

| Method     | Runtime            | BuildConfiguration | ReadSize | Mean     | Error   | StdDev  | Ratio | Rank |
|----------- |------------------- |------------------- |--------- |---------:|--------:|--------:|------:|-----:|
| Decompress | .NET Framework 4.8 | Previous           | 16384    | 296.1 us | 1.37 us | 1.28 us |  1.00 |    1 |
| Decompress | .NET Framework 4.8 | Default            | 16384    | 288.4 us | 1.22 us | 1.02 us |  0.97 |    1 |
|            |                    |                    |          |          |         |         |       |      |
| Decompress | .NET 6.0           | Previous           | 16384    | 141.9 us | 0.53 us | 0.47 us |  1.00 |    1 |
| Decompress | .NET 6.0           | Default            | 16384    | 138.7 us | 0.53 us | 0.49 us |  0.98 |    1 |
|            |                    |                    |          |          |         |         |       |      |
| Decompress | .NET 8.0           | Previous           | 16384    | 159.5 us | 0.40 us | 0.38 us |  1.00 |    2 |
| Decompress | .NET 8.0           | Default            | 16384    | 124.5 us | 0.50 us | 0.47 us |  0.78 |    1 |
|            |                    |                    |          |          |         |         |       |      |
| Decompress | .NET 9.0           | Previous           | 16384    | 142.4 us | 0.58 us | 0.54 us |  1.00 |    2 |
| Decompress | .NET 9.0           | Default            | 16384    | 112.6 us | 0.37 us | 0.35 us |  0.79 |    1 |