### PR TITLE
Add TryCompress and TryDecompress

### DIFF
--- a/Snappier.Benchmarks/BlockCompressHtml.cs
+++ b/Snappier.Benchmarks/BlockCompressHtml.cs
@@ -27,7 +27,9 @@ namespace Snappier.Benchmarks
         {
             using var compressor = new SnappyCompressor();
 
+#pragma warning disable CS0618 // Type or member is obsolete
             return compressor.Compress(_input.Span, _output.Span);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/Snappier.Benchmarks/Overview.cs
+++ b/Snappier.Benchmarks/Overview.cs
@@ -53,7 +53,9 @@ namespace Snappier.Benchmarks
         {
             using var compressor = new SnappyCompressor();
 
+#pragma warning disable CS0618 // Type or member is obsolete
             return compressor.Compress(_htmlMemory.Span, _outputBuffer.Span);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Benchmark]

--- a/Snappier/Internal/SnappyStreamCompressor.cs
+++ b/Snappier/Internal/SnappyStreamCompressor.cs
@@ -214,7 +214,11 @@ namespace Snappier.Internal
             // Make room for the header and CRC
             Span<byte> blockBody = output.Slice(headerSize);
 
-            int bytesWritten = _compressor.Compress(input, blockBody);
+            if (!_compressor.TryCompress(input, blockBody, out int bytesWritten))
+            {
+                // Should be unreachable since we're allocating a buffer of the correct size.
+                ThrowHelper.ThrowInvalidOperationException();
+            }
 
             if (bytesWritten < input.Length)
             {

--- a/Snappier/Internal/ThrowHelper.cs
+++ b/Snappier/Internal/ThrowHelper.cs
@@ -33,11 +33,21 @@ namespace Snappier.Internal
 #endif
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Avoid inlining to reduce code size for a cold path
+        public static void ThrowArgumentExceptionInsufficientOutputBuffer(string? paramName) =>
+            ThrowArgumentException("Output buffer is too small.", paramName);
+
+        [DoesNotReturn]
         public static void ThrowInvalidDataException(string? message) =>
             throw new InvalidDataException(message);
 
         [DoesNotReturn]
-        public static void ThrowInvalidOperationException(string? message) =>
+        [MethodImpl(MethodImplOptions.NoInlining)] // Avoid inlining to reduce code size for a cold path
+        public static void ThrowInvalidDataExceptionIncompleteSnappyBlock() =>
+            throw new InvalidDataException("Incomplete Snappy block.");
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException(string? message = null) =>
             throw new InvalidOperationException(message);
 
         [DoesNotReturn]


### PR DESCRIPTION
These methods handle insufficient output buffer sizes without throwing an exception, instead returning false.