### PR TITLE
Clear buffers before returning them to the ArrayPool

### DIFF
--- a/Snappier/Internal/ByteArrayPoolMemoryOwner.cs
+++ b/Snappier/Internal/ByteArrayPoolMemoryOwner.cs
@@ -45,6 +45,9 @@ namespace Snappier.Internal
             byte[]? innerArray = _innerArray;
             if (innerArray is not null)
             {
+                // Clear the used portion of the array before returning it to the pool
+                Memory.Span.Clear();
+
                 _innerArray = null;
                 Memory = default;
                 ArrayPool<byte>.Shared.Return(innerArray);

--- a/Snappier/Internal/SnappyDecompressor.cs
+++ b/Snappier/Internal/SnappyDecompressor.cs
@@ -526,7 +526,8 @@ namespace Snappier.Internal
                 {
                     if (_lookbackBufferArray is not null)
                     {
-                        ArrayPool<byte>.Shared.Return(_lookbackBufferArray);
+                        // Clear the used portion of the lookback buffer before returning
+                        Helpers.ClearAndReturn(_lookbackBufferArray, _lookbackPosition);
                     }
 
                     if (BufferWriter is not null)
@@ -731,7 +732,9 @@ namespace Snappier.Internal
         {
             if (_lookbackBufferArray is not null)
             {
-                ArrayPool<byte>.Shared.Return(_lookbackBufferArray);
+                // Clear the used portion of the lookback buffer before returning
+                Helpers.ClearAndReturn(_lookbackBufferArray, _lookbackPosition);
+
                 _lookbackBufferArray = null;
                 _lookbackBuffer = default;
             }

--- a/Snappier/Internal/SnappyStreamCompressor.cs
+++ b/Snappier/Internal/SnappyStreamCompressor.cs
@@ -276,7 +276,7 @@ namespace Snappier.Internal
         {
             // Allocate enough room for the stream header and block headers
             _outputBuffer ??=
-                ArrayPool<byte>.Shared.Rent(Helpers.MaxCompressedLength((int) Constants.BlockSize) + 8 + SnappyHeader.Length);
+                ArrayPool<byte>.Shared.Rent(Helpers.MaxBlockCompressedLength + 8 + SnappyHeader.Length);
 
             // Allocate enough room for the stream header and block headers
             _inputBuffer ??= ArrayPool<byte>.Shared.Rent((int) Constants.BlockSize);
@@ -289,12 +289,12 @@ namespace Snappier.Internal
 
             if (_outputBuffer is not null)
             {
-                ArrayPool<byte>.Shared.Return(_outputBuffer);
+                ArrayPool<byte>.Shared.Return(_outputBuffer, clearArray: true);
                 _outputBuffer = null;
             }
             if (_inputBuffer is not null)
             {
-                ArrayPool<byte>.Shared.Return(_inputBuffer);
+                ArrayPool<byte>.Shared.Return(_inputBuffer, clearArray: true);
                 _inputBuffer = null;
             }
         }

--- a/Snappier/Snappy.cs
+++ b/Snappier/Snappy.cs
@@ -102,21 +102,16 @@ namespace Snappier
         {
             byte[] buffer = ArrayPool<byte>.Shared.Rent(GetMaxCompressedLength(input.Length));
 
-            try
+            if (!TryCompress(input, buffer, out int length))
             {
-                if (!TryCompress(input, buffer, out int length))
-                {
-                    // Should be unreachable since we're allocating a buffer of the correct size.
-                    ThrowHelper.ThrowInvalidOperationException();
-                }
+                // The amount of data written is unknown, so clear the entire buffer when returning
+                ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
 
-                return new ByteArrayPoolMemoryOwner(buffer, length);
+                // Should be unreachable since we're allocating a buffer of the correct size.
+                ThrowHelper.ThrowInvalidOperationException();
             }
-            catch
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-                throw;
-            }
+
+            return new ByteArrayPoolMemoryOwner(buffer, length);
         }
 
         /// <summary>

--- a/Snappier/SnappyStream.cs
+++ b/Snappier/SnappyStream.cs
@@ -494,7 +494,7 @@ namespace Snappier
                             _buffer = null;
                             if (!AsyncOperationIsActive)
                             {
-                                ArrayPool<byte>.Shared.Return(buffer);
+                                ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
                             }
                         }
 
@@ -545,7 +545,7 @@ namespace Snappier
                             _buffer = null;
                             if (!AsyncOperationIsActive)
                             {
-                                ArrayPool<byte>.Shared.Return(buffer);
+                                ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
                             }
                         }
                     }


### PR DESCRIPTION
It is possible that sensitive data such as PII is being compressed or decompressed using Snappier. We don't want to return such data to the ArrayPool without zeroing it first, as it could create a security vulnerability if the buffer is reused by some other portion of an application that isn't properly handling the buffer.

In some cases, we request the clear as part of the return. However, in others we know we've only used a subset of the buffer so we can optimize by only clearing the portion we've used.

This change also removes some unnecessary try..finally blocks to return arrays to the pool during compression. Compression doesn't typically throw exceptions, and in any extreme corner cases we'll simply not return the array to the pool. This simplifies the code and provides a minor performance improvement.