### PR TITLE
Add initial support for .NET 10

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    
+
     permissions:
       security-events: write
 
@@ -29,11 +29,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Setup .NET 6.0
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,14 +18,14 @@ jobs:
         disable: ["HWIntrinsics", "SSSE3", "BMI2", "Noop"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-          6.0.x
           8.0.x
           9.0.x
+          10.0.x
     # Cache packages for faster subsequent runs
     - uses: actions/cache@v4
       with:
@@ -57,13 +57,13 @@ jobs:
         framework: ["net8.0", "net9.0"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-          8.0.x
           9.0.x
+          10.0.x
     # Cache packages for faster subsequent runs
     - uses: actions/cache@v4
       with:
@@ -94,11 +94,11 @@ jobs:
         arch: ["x64", "x86"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
     # Cache packages for faster subsequent runs
     - uses: actions/cache@v4
       with:
@@ -128,11 +128,11 @@ jobs:
       - test-windows
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
     - name: Download Coverage
       uses: actions/download-artifact@v4
       with:
@@ -169,11 +169,11 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/release/') }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  
+
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
@@ -14,15 +14,15 @@ concurrency:
 jobs:
   build-docs:
     name: Build Documentation
-    
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Install docfX
         run: dotnet tool update -g docfx
@@ -30,7 +30,7 @@ jobs:
         run: docfx docfx.json
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: 'artifacts/_site'
 

--- a/Snappier.Benchmarks/Configuration/FrameworkCompareConfig.cs
+++ b/Snappier.Benchmarks/Configuration/FrameworkCompareConfig.cs
@@ -19,12 +19,13 @@ namespace Snappier.Benchmarks.Configuration
             #endif
 
             AddJob(baseJob
-                .WithRuntime(CoreRuntime.Core60));
-            AddJob(baseJob
                 .WithRuntime(CoreRuntime.Core80)
                 .WithPgo(true));
             AddJob(baseJob
                 .WithRuntime(CoreRuntime.Core90)
+                .WithPgo(true));
+            AddJob(baseJob
+                .WithRuntime(CoreRuntime.Core10_0)
                 .WithPgo(true));
 
             AddLogicalGroupRules(BenchmarkLogicalGroupRule.ByJob);

--- a/Snappier.Benchmarks/Snappier.Benchmarks.csproj
+++ b/Snappier.Benchmarks/Snappier.Benchmarks.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net48;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net9.0;net10.0</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
 
     <IsPackable>false</IsPackable>
-    <LangVersion>12</LangVersion>
+    <LangVersion>14</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Snappier.snk</AssemblyOriginatorKeyFile>
     <NoWarn>$(NoWarn);8002</NoWarn> <!-- Don't nag about Snappy.NET not being strong named -->
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.2" />
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net48'))">
@@ -30,15 +30,15 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(Configuration)' != 'Previous' ">
     <ProjectReference Include="..\Snappier\Snappier.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(Configuration)' == 'Previous' ">
-    <PackageReference Include="Snappier" Version="1.1.6" />
+    <PackageReference Include="Snappier" Version="1.2.0" />
 
     <Compile Remove="FindMatchLength.cs" />
     <Compile Remove="IncrementalCopy.cs" />

--- a/Snappier.Tests/Snappier.Tests.csproj
+++ b/Snappier.Tests/Snappier.Tests.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net48</TargetFrameworks>
+    <OutputType>Exe</OutputType>
 
     <IsPackable>false</IsPackable>
-    <LangVersion>12</LangVersion>
+    <LangVersion>14</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Snappier.snk</AssemblyOriginatorKeyFile>
 
@@ -20,21 +21,21 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Snappier/Internal/ByteArrayPoolMemoryOwner.cs
+++ b/Snappier/Internal/ByteArrayPoolMemoryOwner.cs
@@ -33,7 +33,7 @@ namespace Snappier.Internal
         /// <param name="length">The length of the array to return from <see cref="Memory"/>.</param>
         public ByteArrayPoolMemoryOwner(byte[] innerArray, int length)
         {
-            ThrowHelper.ThrowIfNull(innerArray);
+            ArgumentNullException.ThrowIfNull(innerArray);
 
             _innerArray = innerArray;
             Memory = innerArray.AsMemory(0, length); // Also validates length

--- a/Snappier/Internal/SnappyCompressor.cs
+++ b/Snappier/Internal/SnappyCompressor.cs
@@ -24,10 +24,7 @@ namespace Snappier.Internal
 
         public bool TryCompress(ReadOnlySpan<byte> input, Span<byte> output, out int bytesWritten)
         {
-            if (_workingMemory == null)
-            {
-                ThrowHelper.ThrowObjectDisposedException(nameof(SnappyCompressor));
-            }
+            ObjectDisposedException.ThrowIf(_workingMemory is null, this);
             if (input.Overlaps(output))
             {
                 ThrowHelper.ThrowInvalidOperationException("Input and output spans must not overlap.");
@@ -85,15 +82,12 @@ namespace Snappier.Internal
 
         public void Compress(ReadOnlySequence<byte> input, IBufferWriter<byte> bufferWriter)
         {
-            ThrowHelper.ThrowIfNull(bufferWriter);
+            ArgumentNullException.ThrowIfNull(bufferWriter);
             if (input.Length > uint.MaxValue)
             {
                 ThrowHelper.ThrowArgumentException($"{nameof(input)} is larger than the maximum size of {uint.MaxValue} bytes.", nameof(input));
             }
-            if (_workingMemory is null)
-            {
-                ThrowHelper.ThrowObjectDisposedException(nameof(SnappyCompressor));
-            }
+            ObjectDisposedException.ThrowIf(_workingMemory is null, this);
 
             _workingMemory.EnsureCapacity(input.Length);
 
@@ -227,7 +221,7 @@ namespace Snappier.Internal
                         // number of bytes to move ahead for each iteration.
                         int skip = 32;
 
-                        ref byte candidate = ref Unsafe.NullRef<byte>();
+                        scoped ref byte candidate = ref Unsafe.NullRef<byte>();
                         if (Unsafe.ByteOffset(ref ip, ref ipLimit) >= (nint) 16)
                         {
                             nint delta = Unsafe.ByteOffset(ref inputStart, ref ip);

--- a/Snappier/Internal/SnappyDecompressor.cs
+++ b/Snappier/Internal/SnappyDecompressor.cs
@@ -11,9 +11,6 @@ namespace Snappier.Internal
     internal sealed class SnappyDecompressor : IDisposable
     {
 #if NET8_0_OR_GREATER
-#pragma warning disable IDE0051
-#pragma warning disable IDE0044
-#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
         [InlineArray(Constants.MaximumTagLength)]
         private struct ScratchBuffer
         {
@@ -23,9 +20,6 @@ namespace Snappier.Internal
         private ScratchBuffer _scratch;
 
         private Span<byte> Scratch => _scratch;
-#pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
-#pragma warning restore IDE0044
-#pragma warning restore IDE0051
 #else
         private readonly byte[] _scratch = new byte[Constants.MaximumTagLength];
 
@@ -134,7 +128,7 @@ namespace Snappier.Internal
                 switch (status)
                 {
                     case OperationStatus.Done:
-                        ExpectedLength = (int)length;
+                ExpectedLength = (int)length;
 
                         // The number of bytes consumed from the input is the number of bytes used by VarIntEncoding.TryRead
                         // less the number of bytes previously found in the scratch buffer
@@ -514,13 +508,12 @@ namespace Snappier.Internal
         private int _lookbackPosition = 0;
         private int _readPosition = 0;
 
-        private int? _expectedLength;
         private int? ExpectedLength
         {
-            get => _expectedLength;
+            get;
             set
             {
-                _expectedLength = value;
+                field = value;
 
                 if (value.HasValue && _lookbackBuffer.Length < value.GetValueOrDefault())
                 {
@@ -626,7 +619,7 @@ namespace Snappier.Internal
                 ThrowCannotUseWithBufferWriter(nameof(Read));
             }
 
-            var bytesToRead = Math.Min(destination.Length, UnreadBytes);
+            int bytesToRead = Math.Min(destination.Length, UnreadBytes);
             if (bytesToRead <= 0)
             {
                 return 0;
@@ -708,7 +701,7 @@ namespace Snappier.Internal
         /// </summary>
         internal void LoadScratchForTest(byte[] newScratch, int newScratchLength)
         {
-            ThrowHelper.ThrowIfNull(newScratch);
+            ArgumentNullException.ThrowIfNull(newScratch);
             if (newScratchLength > ((ReadOnlySpan<byte>)_scratch).Length)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(nameof(newScratchLength), "Scratch length exceeds limit");

--- a/Snappier/Internal/SnappyStreamCompressor.cs
+++ b/Snappier/Internal/SnappyStreamCompressor.cs
@@ -42,11 +42,8 @@ namespace Snappier.Internal
         /// <returns>A block of memory with compressed data (if any). Must be used before any subsequent call to Write.</returns>
         public void Write(ReadOnlySpan<byte> input, Stream stream)
         {
-            ThrowHelper.ThrowIfNull(stream);
-            if (_compressor == null)
-            {
-                ThrowHelper.ThrowObjectDisposedException(nameof(SnappyStreamCompressor));
-            }
+            ArgumentNullException.ThrowIfNull(stream);
+            ObjectDisposedException.ThrowIf(_compressor is null, this);
 
             EnsureBuffer();
             EnsureStreamHeaderWritten();
@@ -70,11 +67,8 @@ namespace Snappier.Internal
         /// <returns>A block of memory with compressed data (if any). Must be used before any subsequent call to Write.</returns>
         public async ValueTask WriteAsync(ReadOnlyMemory<byte> input, Stream stream, CancellationToken cancellationToken = default)
         {
-            ThrowHelper.ThrowIfNull(stream);
-            if (_compressor == null)
-            {
-                ThrowHelper.ThrowObjectDisposedException(nameof(SnappyStreamCompressor));
-            }
+            ArgumentNullException.ThrowIfNull(stream);
+            ObjectDisposedException.ThrowIf(_compressor is null, this);
 
             EnsureBuffer();
             EnsureStreamHeaderWritten();
@@ -90,11 +84,8 @@ namespace Snappier.Internal
 
         public void Flush(Stream stream)
         {
-            ThrowHelper.ThrowIfNull(stream);
-            if (_compressor == null)
-            {
-                ThrowHelper.ThrowObjectDisposedException(nameof(SnappyStreamCompressor));
-            }
+            ArgumentNullException.ThrowIfNull(stream);
+            ObjectDisposedException.ThrowIf(_compressor is null, this);
 
             EnsureBuffer();
             EnsureStreamHeaderWritten();
@@ -110,11 +101,8 @@ namespace Snappier.Internal
 
         public async ValueTask FlushAsync(Stream stream, CancellationToken cancellationToken = default)
         {
-            ThrowHelper.ThrowIfNull(stream);
-            if (_compressor == null)
-            {
-                ThrowHelper.ThrowObjectDisposedException(nameof(SnappyStreamCompressor));
-            }
+            ArgumentNullException.ThrowIfNull(stream);
+            ObjectDisposedException.ThrowIf(_compressor is null, this);
 
             EnsureBuffer();
             EnsureStreamHeaderWritten();

--- a/Snappier/Internal/SnappyStreamDecompressor.cs
+++ b/Snappier/Internal/SnappyStreamDecompressor.cs
@@ -12,9 +12,6 @@ namespace Snappier.Internal
         private const int ScratchBufferSize = 4;
 
 #if NET8_0_OR_GREATER
-#pragma warning disable IDE0051
-#pragma warning disable IDE0044
-#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
         [System.Runtime.CompilerServices.InlineArray(ScratchBufferSize)]
         private struct ScratchBuffer
         {
@@ -22,9 +19,6 @@ namespace Snappier.Internal
         }
 
         private ScratchBuffer _scratch;
-#pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
-#pragma warning restore IDE0044
-#pragma warning restore IDE0051
 #else
         private readonly byte[] _scratch = new byte[ScratchBufferSize];
 #endif

--- a/Snappier/Internal/ThrowHelper.cs
+++ b/Snappier/Internal/ThrowHelper.cs
@@ -3,26 +3,51 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 
-namespace Snappier.Internal
+namespace Snappier.Internal;
+
+internal static class ThrowHelper
 {
-    internal static class ThrowHelper
+    [DoesNotReturn]
+    public static void ThrowArgumentException(string? message, string? paramName) =>
+        throw new ArgumentException(message, paramName);
+
+    [DoesNotReturn]
+    public static void ThrowArgumentOutOfRangeException(string? paramName, string? message) =>
+        throw new ArgumentOutOfRangeException(paramName, message);
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)] // Avoid inlining to reduce code size for a cold path
+    public static void ThrowArgumentExceptionInsufficientOutputBuffer(string? paramName) =>
+        ThrowArgumentException("Output buffer is too small.", paramName);
+
+    [DoesNotReturn]
+    public static void ThrowInvalidDataException(string? message) =>
+        throw new InvalidDataException(message);
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)] // Avoid inlining to reduce code size for a cold path
+    public static void ThrowInvalidDataExceptionIncompleteSnappyBlock() =>
+        throw new InvalidDataException("Incomplete Snappy block.");
+
+    [DoesNotReturn]
+    public static void ThrowInvalidOperationException(string? message = null) =>
+        throw new InvalidOperationException(message);
+
+    [DoesNotReturn]
+    public static void ThrowNotSupportedException(string? message = null) =>
+        throw new NotSupportedException(message);
+
+#if NETSTANDARD2_0
+    [DoesNotReturn]
+    private static void ThrowArgumentNullException(string? paramName) =>
+        throw new ArgumentNullException(paramName);
+
+    [DoesNotReturn]
+    private static void ThrowObjectDisposedException(object? instance) =>
+        throw new ObjectDisposedException(instance?.GetType().FullName);
+
+    extension(ArgumentNullException)
     {
-        [DoesNotReturn]
-        public static void ThrowArgumentException(string? message, string? paramName) =>
-            throw new ArgumentException(message, paramName);
-
-        [DoesNotReturn]
-        public static void ThrowArgumentOutOfRangeException(string? paramName, string? message) =>
-            throw new ArgumentOutOfRangeException(paramName, message);
-
-#if NET6_0_OR_GREATER
-        public static void ThrowIfNull([NotNull] object? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null) =>
-            ArgumentNullException.ThrowIfNull(argument, paramName);
-#else
-        [DoesNotReturn]
-        private static void ThrowArgumentNullException(string? paramName) =>
-            throw new ArgumentNullException(paramName);
-
         public static void ThrowIfNull([NotNull] object? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
         {
             if (argument is null)
@@ -30,32 +55,17 @@ namespace Snappier.Internal
                 ThrowArgumentNullException(paramName);
             }
         }
-#endif
-
-        [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)] // Avoid inlining to reduce code size for a cold path
-        public static void ThrowArgumentExceptionInsufficientOutputBuffer(string? paramName) =>
-            ThrowArgumentException("Output buffer is too small.", paramName);
-
-        [DoesNotReturn]
-        public static void ThrowInvalidDataException(string? message) =>
-            throw new InvalidDataException(message);
-
-        [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)] // Avoid inlining to reduce code size for a cold path
-        public static void ThrowInvalidDataExceptionIncompleteSnappyBlock() =>
-            throw new InvalidDataException("Incomplete Snappy block.");
-
-        [DoesNotReturn]
-        public static void ThrowInvalidOperationException(string? message = null) =>
-            throw new InvalidOperationException(message);
-
-        [DoesNotReturn]
-        public static void ThrowNotSupportedException(string? message = null) =>
-            throw new NotSupportedException(message);
-
-        [DoesNotReturn]
-        public static void ThrowObjectDisposedException(string? objectName) =>
-            throw new ObjectDisposedException(objectName);
     }
+
+    extension(ObjectDisposedException)
+    {
+        public static void ThrowIf([DoesNotReturnIf(true)] bool condition, object instance)
+        {
+            if (condition)
+            {
+                ThrowObjectDisposedException(instance);
+            }
+        }
+    }
+#endif
 }

--- a/Snappier/Internal/VarIntEncoding.Read.cs
+++ b/Snappier/Internal/VarIntEncoding.Read.cs
@@ -16,7 +16,7 @@ namespace Snappier.Internal
     {
         public static uint Read(ReadOnlySpan<byte> input, out int bytesRead)
         {
-            if (TryRead(input, out var result, out bytesRead) != OperationStatus.Done)
+            if (TryRead(input, out uint result, out bytesRead) != OperationStatus.Done)
             {
                 ThrowHelper.ThrowInvalidDataException("Invalid stream length");
             }
@@ -98,7 +98,7 @@ namespace Snappier.Internal
             Debug.Assert(input.Length >= Vector128<byte>.Count);
             Debug.Assert(BitConverter.IsLittleEndian);
 
-            var mask = ~Sse2.MoveMask(Vector128.LoadUnsafe(ref MemoryMarshal.GetReference(input)));
+            int mask = ~Sse2.MoveMask(Vector128.LoadUnsafe(ref MemoryMarshal.GetReference(input)));
             bytesRead = BitOperations.TrailingZeroCount(mask) + 1;
 
             uint shuffledBits = Bmi2.X64.IsSupported

--- a/Snappier/Snappier.csproj
+++ b/Snappier/Snappier.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
 
-    <LangVersion>12</LangVersion>
+    <LangVersion>14</LangVersion>
     <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Snappier.snk</AssemblyOriginatorKeyFile>
@@ -49,9 +49,9 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Memory" Version="4.6.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>
 
 </Project>

--- a/Snappier/Snappy.cs
+++ b/Snappier/Snappy.cs
@@ -38,7 +38,7 @@ namespace Snappier
         /// </remarks>
         public static int Compress(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            if (!TryCompress(input, output, out var bytesWritten))
+            if (!TryCompress(input, output, out int bytesWritten))
             {
                 ThrowHelper.ThrowArgumentExceptionInsufficientOutputBuffer(nameof(output));
             }
@@ -83,7 +83,7 @@ namespace Snappier
         /// </remarks>
         public static void Compress(ReadOnlySequence<byte> input, IBufferWriter<byte> output)
         {
-            ThrowHelper.ThrowIfNull(output);
+            ArgumentNullException.ThrowIfNull(output);
 
             using var compressor = new SnappyCompressor();
 
@@ -195,7 +195,7 @@ namespace Snappier
         /// <exception cref="InvalidDataException">Invalid Snappy block.</exception>
         public static void Decompress(ReadOnlySequence<byte> input, IBufferWriter<byte> output)
         {
-            ThrowHelper.ThrowIfNull(output);
+            ArgumentNullException.ThrowIfNull(output);
 
             using var decompressor = new SnappyDecompressor()
             {

--- a/Snappier/SnappyStream.cs
+++ b/Snappier/SnappyStream.cs
@@ -58,7 +58,7 @@ namespace Snappier
         /// <exception cref="ArgumentOutOfRangeException">Invalid <paramref name="mode"/>.</exception>
         public SnappyStream(Stream stream, CompressionMode mode, bool leaveOpen)
         {
-            ThrowHelper.ThrowIfNull(stream);
+            ArgumentNullException.ThrowIfNull(stream);
             _stream = stream;
             _mode = mode;
             _leaveOpen = leaveOpen;
@@ -559,10 +559,7 @@ namespace Snappier
         [MemberNotNull(nameof(_stream))]
         private void EnsureNotDisposed()
         {
-            if (_stream == null)
-            {
-                ThrowHelper.ThrowObjectDisposedException(nameof(SnappyStream));
-            }
+            ObjectDisposedException.ThrowIf(_stream is null, this);
         }
 
         private void EnsureDecompressionMode()

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "9.0.100",
+        "version": "10.0.100-rc.1.25451.107",
         "rollForward": "latestFeature"
     }
 }


### PR DESCRIPTION
- Update to use the .NET 10 RC1 SDK
- Use C# 14
- Use C# 14 extensions to clean up exception helpers
- Add .NET 10 targets for benchmarks and unit tests
- Drop outdated .NET 6 targets
- Update various NuGet package dependencies
- Update Benchmark.Net for .NET 10 support
- Update to xUnit v3
- Address compiler various warnings and suggestions, and remove some suppressions that are no longer necessary
- Update GitHub Actions versions