### PR TITLE
Use "ref readonly" for readonly input references

### DIFF
--- a/Snappier.Benchmarks/Configuration/JobExtensions.cs
+++ b/Snappier.Benchmarks/Configuration/JobExtensions.cs
@@ -1,9 +1,10 @@
-﻿using BenchmarkDotNet.Jobs;
-
-namespace Snappier.Benchmarks.Configuration;
+﻿namespace Snappier.Benchmarks.Configuration;
 
 public static class JobExtensions
 {
-    public static Job WithPgo(this Job job, bool enabled = true) =>
-        job.WithEnvironmentVariable(PgoColumn.PgoEnvironmentVariableName, enabled ? "1" : "0");
+    extension(Job job)
+    {
+        public Job WithPgo(bool enabled = true) =>
+            job.WithEnvironmentVariable(PgoColumn.PgoEnvironmentVariableName, enabled ? "1" : "0");
+    }
 }

--- a/Snappier.Benchmarks/Configuration/VersionComparisonConfig.cs
+++ b/Snappier.Benchmarks/Configuration/VersionComparisonConfig.cs
@@ -18,20 +18,20 @@ public class VersionComparisonConfig : StandardConfig
     {
         Job jobBefore = baseJob.WithCustomBuildConfiguration("Previous");
 
-        Job jobBefore60 = jobBefore.WithRuntime(CoreRuntime.Core60).AsBaseline();
         Job jobBefore80 = jobBefore.WithRuntime(CoreRuntime.Core80).WithPgo().AsBaseline();
         Job jobBefore90 = jobBefore.WithRuntime(CoreRuntime.Core90).WithPgo().AsBaseline();
+        Job jobBefore10_0 = jobBefore.WithRuntime(CoreRuntime.Core10_0).WithPgo().AsBaseline();
 
-        Job jobAfter60 = baseJob.WithRuntime(CoreRuntime.Core60);
         Job jobAfter80 = baseJob.WithRuntime(CoreRuntime.Core80).WithPgo();
         Job jobAfter90 = baseJob.WithRuntime(CoreRuntime.Core90).WithPgo();
+        Job jobAfter10_0 = baseJob.WithRuntime(CoreRuntime.Core10_0).WithPgo();
 
-        AddJob(jobBefore60);
         AddJob(jobBefore80);
         AddJob(jobBefore90);
-        AddJob(jobAfter60);
+        AddJob(jobBefore10_0);
         AddJob(jobAfter80);
         AddJob(jobAfter90);
+        AddJob(jobAfter10_0);
 
 #if NET6_0_OR_GREATER // OperatingSystem check is only available in .NET 6.0 or later, but the runner itself won't be .NET 4 anyway
         if (OperatingSystem.IsWindows())

--- a/Snappier.Benchmarks/IncrementalCopy.cs
+++ b/Snappier.Benchmarks/IncrementalCopy.cs
@@ -10,7 +10,7 @@ public class IncrementalCopy
     public void Fast()
     {
         ref byte buffer = ref _buffer[0];
-        CopyHelpers.IncrementalCopy(ref buffer, ref Unsafe.Add(ref buffer, 2), ref Unsafe.Add(ref buffer, 18),
+        CopyHelpers.IncrementalCopy(in buffer, ref Unsafe.Add(ref buffer, 2), ref Unsafe.Add(ref buffer, 18),
             ref Unsafe.Add(ref buffer, _buffer.Length - 1));
     }
 

--- a/Snappier.Tests/Internal/SnappyCompressorTests.cs
+++ b/Snappier.Tests/Internal/SnappyCompressorTests.cs
@@ -85,11 +85,11 @@ public class SnappyCompressorTests
                                                      + new string('\0', Math.Max(0, length - s2String.Length)));
 
         ulong data = 0;
-        ref byte s1 = ref array[0];
-        ref byte s2 = ref Unsafe.Add(ref s1, s1String.Length);
+        ref readonly byte s1 = ref array[0];
+        ref readonly byte s2 = ref Unsafe.Add(in s1, s1String.Length);
 
         (int matchLength, bool matchLengthLessThan8) =
-            SnappyCompressor.FindMatchLength(ref s1, ref s2, ref Unsafe.Add(ref s2, length), ref data);
+            SnappyCompressor.FindMatchLength(in s1, in s2, in Unsafe.Add(in s2, length), ref data);
 
         Assert.Equal(matchLength < 8, matchLengthLessThan8);
         Assert.Equal(expectedResult, matchLength);

--- a/Snappier/Internal/Helpers.cs
+++ b/Snappier/Internal/Helpers.cs
@@ -86,9 +86,10 @@ internal static class Helpers
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static uint UnsafeReadUInt32(in byte ptr)
+    public static uint UnsafeReadUInt32(ref readonly byte ptr)
     {
-        uint result = Unsafe.ReadUnaligned<uint>(ref Unsafe.AsRef(in ptr));
+        uint result = Unsafe.ReadUnaligned<uint>(in ptr);
+
         if (!BitConverter.IsLittleEndian)
         {
             result = BinaryPrimitives.ReverseEndianness(result);
@@ -98,9 +99,10 @@ internal static class Helpers
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ulong UnsafeReadUInt64(in byte ptr)
+    public static ulong UnsafeReadUInt64(ref readonly byte ptr)
     {
-        ulong result = Unsafe.ReadUnaligned<ulong>(ref Unsafe.AsRef(in ptr));
+        ulong result = Unsafe.ReadUnaligned<ulong>(in ptr);
+
         if (!BitConverter.IsLittleEndian)
         {
             result = BinaryPrimitives.ReverseEndianness(result);

--- a/Snappier/Internal/UnsafeReadonly.cs
+++ b/Snappier/Internal/UnsafeReadonly.cs
@@ -1,0 +1,62 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Snappier.Internal;
+
+/// <summary>
+/// Helpers to perform Unsafe.Add operations on readonly refs.
+/// </summary>
+internal static class UnsafeReadonly
+{
+    extension(Unsafe)
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref readonly T Add<T>(ref readonly T source, int elementOffset) =>
+            ref Unsafe.Add(ref Unsafe.AsRef(in source), elementOffset);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref readonly T Add<T>(ref readonly T source, nint elementOffset) =>
+            ref Unsafe.Add(ref Unsafe.AsRef(in source), elementOffset);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref readonly T Add<T>(ref readonly T source, nuint elementOffset) =>
+            ref Unsafe.Add(ref Unsafe.AsRef(in source), elementOffset);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref readonly TTo As<TFrom, TTo>(ref readonly TFrom source) =>
+            ref Unsafe.As<TFrom, TTo>(ref Unsafe.AsRef(in source));
+
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static nint ByteOffset<T>(ref readonly T origin, ref readonly T target) =>
+            Unsafe.ByteOffset(ref Unsafe.AsRef(in origin), ref Unsafe.AsRef(in target));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyBlockUnaligned(ref byte destination, ref readonly byte source, uint byteCount) =>
+            Unsafe.CopyBlockUnaligned(ref destination, ref Unsafe.AsRef(in source), byteCount);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsAddressGreaterThan<T>(ref readonly T left, ref readonly T right) =>
+            Unsafe.IsAddressGreaterThan(ref Unsafe.AsRef(in left), ref Unsafe.AsRef(in right));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsAddressLessThan<T>(ref readonly T left, ref readonly T right) =>
+            Unsafe.IsAddressLessThan(ref Unsafe.AsRef(in left), ref Unsafe.AsRef(in right));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T ReadUnaligned<T>(ref readonly byte source) =>
+            Unsafe.ReadUnaligned<T>(ref Unsafe.AsRef(in source));
+#endif
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref readonly T Subtract<T>(ref readonly T source, int elementOffset) =>
+            ref Unsafe.Subtract(ref Unsafe.AsRef(in source), elementOffset);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref readonly T Subtract<T>(ref readonly T source, nint elementOffset) =>
+            ref Unsafe.Subtract(ref Unsafe.AsRef(in source), elementOffset);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref readonly T Subtract<T>(ref readonly T source, nuint elementOffset) =>
+            ref Unsafe.Subtract(ref Unsafe.AsRef(in source), elementOffset);
+    }
+}

--- a/Snappier/Internal/UnsafeReadonly.cs
+++ b/Snappier/Internal/UnsafeReadonly.cs
@@ -2,9 +2,7 @@
 
 namespace Snappier.Internal;
 
-/// <summary>
-/// Helpers to perform Unsafe.Add operations on readonly refs.
-/// </summary>
+// Helpers to perform Unsafe.Add operations on readonly refs.
 internal static class UnsafeReadonly
 {
     extension(Unsafe)


### PR DESCRIPTION
This provides consistent semantics to help prevent coding errors. The only reason this wasn't used before was because so many of the methods in the System.Runtime.CompilerServices.Unsafe class take "ref" parameters, especially in .NET Standard, and calling Unsafe.AsRef at every callsite was beyond cumbersome.

Now, however, extension static members in C# 14 have made this completely transparent. The compiler selects the correct overload automatically based on the input parameter.