### PR TITLE
Use OIDC for NuGet package publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        framework: ["net6.0", "net8.0", "net9.0"]
+        framework: ["net8.0", "net9.0"]
         disable: ["HWIntrinsics", "SSSE3", "BMI2", "Noop"]
 
     steps:
@@ -62,6 +62,7 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
+          8.0.x
           9.0.x
           10.0.x
     # Cache packages for faster subsequent runs
@@ -165,8 +166,13 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - test
+    - test-arm
     - test-windows
     if: ${{ startsWith(github.ref, 'refs/tags/release/') }}
+
+    permissions:
+      contents: read
+      id-token: write  # enable GitHub OIDC token issuance for this job
 
     steps:
     - uses: actions/checkout@v5
@@ -174,6 +180,12 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
+
+    - name: NuGet login (OIDC → temp API key)
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }}
 
     - name: Install dependencies
       run: dotnet restore
@@ -184,4 +196,4 @@ jobs:
       run: dotnet pack --configuration Release -p:Version=${{ steps.version.outputs.version }}
     - name: Push to NuGet.org
       run: |
-        dotnet nuget push artifacts/package/**/*.nupkg --api-key ${{ secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+        dotnet nuget push artifacts/package/**/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        framework: ["net8.0", "net9.0"]
+        framework: ["net8.0", "net9.0", "net10.0"]
         disable: ["HWIntrinsics", "SSSE3", "BMI2", "Noop"]
 
     steps:
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
-        framework: ["net8.0", "net9.0"]
+        framework: ["net8.0", "net9.0", "net10.0"]
 
     steps:
     - uses: actions/checkout@v5

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "10.0.100-rc.1.25451.107",
+        "version": "10.0.100-rc.2.25502.107",
         "rollForward": "latestFeature"
     }
 }


### PR DESCRIPTION
Also remove .NET 6 testing, it's been out of support for over a year. Add .NET 10 testing.