### PR TITLE
Correct issues with NuGet validation so we can publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,6 @@ jobs:
     - test
     - test-arm
     - test-windows
-    if: ${{ startsWith(github.ref, 'refs/tags/release/') }}
 
     permissions:
       contents: read
@@ -194,6 +193,12 @@ jobs:
       run: echo "version=${GITHUB_REF/refs\/tags\/release\//}" >> $GITHUB_OUTPUT
     - name: Pack
       run: dotnet pack --configuration Release -p:Version=${{ steps.version.outputs.version }}
+    - name: Upload Package Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: package
+        path: artifacts/package/**
     - name: Push to NuGet.org
+      if: ${{ startsWith(github.ref, 'refs/tags/release/') }}
       run: |
         dotnet nuget push artifacts/package/**/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,6 +180,16 @@ jobs:
       with:
         dotnet-version: 10.0.x
 
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v4
+      with:
+        versionSpec: "6.4.0"
+    - name: Determine Version
+      id: gitversion
+      uses: gittools/actions/gitversion/execute@v4
+      with:
+        configFilePath: "GitVersion.yml"
+
     - name: NuGet login (OIDC → temp API key)
       uses: NuGet/login@v1
       id: login
@@ -188,11 +198,8 @@ jobs:
 
     - name: Install dependencies
       run: dotnet restore
-    - name: Get version
-      id: version
-      run: echo "version=${GITHUB_REF/refs\/tags\/release\//}" >> $GITHUB_OUTPUT
     - name: Pack
-      run: dotnet pack --configuration Release -p:Version=${{ steps.version.outputs.version }}
+      run: dotnet pack --configuration Release -p:Version=${{ steps.gitversion.outputs.fullSemVer }}
     - name: Upload Package Artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,6 +175,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0  # required for GitVersion to work properly
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,1 @@
+workflow: GitHubFlow/v1

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,1 +1,2 @@
 workflow: GitHubFlow/v1
+tag-prefix: release/[vV]?

--- a/Snappier/Snappier.csproj
+++ b/Snappier/Snappier.csproj
@@ -9,9 +9,6 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Snappier.snk</AssemblyOriginatorKeyFile>
 
-    <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>1.1.6</PackageValidationBaselineVersion>
-
     <Authors>btburnett3</Authors>
     <PackageTags>snappy;compression;fast;io</PackageTags>
     <!-- Copyright remains with Google since this is a direct port of the C++ source from https://github.com/google/snappy -->
@@ -43,6 +40,17 @@
     <!-- We want a deterministic build for CI -->
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>1.2.0</PackageValidationBaselineVersion>
+    <ApiCompatEnableRuleCannotChangeParameterName>true</ApiCompatEnableRuleCannotChangeParameterName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- We've removed support for the .NET 6 target framework intentionally -->
+    <PackageValidationBaselineFrameworkToIgnore Include="net6.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="$(PackageReadmeFile)" />


### PR DESCRIPTION
- Bump baseline comparison version to 1.2.0
- Ignore baseline net6.0 target, we've deprecated support
- Pack on every build, not just tags, so validation errors cause build failures
- Enable parameter name change validation