### PR TITLE
Throw useful exception on very short output buffers

### DIFF
--- a/Snappier.Benchmarks/VarIntEncodingRead.cs
+++ b/Snappier.Benchmarks/VarIntEncodingRead.cs
@@ -10,7 +10,7 @@ public class VarIntEncodingRead
     [GlobalSetup]
     public void GlobalSetup()
     {
-        VarIntEncoding.Write(_source, Value);
+        VarIntEncoding.TryWrite(_source, Value, out _);
     }
 
     [Benchmark]

--- a/Snappier.Benchmarks/VarIntEncodingWrite.cs
+++ b/Snappier.Benchmarks/VarIntEncodingWrite.cs
@@ -8,8 +8,8 @@ public class VarIntEncodingWrite
     readonly byte[] _dest = new byte[8];
 
     [Benchmark(Baseline = true)]
-    public int Baseline()
+    public bool Baseline()
     {
-        return VarIntEncoding.Write(_dest, Value);
+        return VarIntEncoding.TryWrite(_dest, Value, out _);
     }
 }

--- a/Snappier.Tests/Internal/VarIntEncodingWriteTests.cs
+++ b/Snappier.Tests/Internal/VarIntEncodingWriteTests.cs
@@ -21,23 +21,35 @@ public class VarIntEncodingWriteTests
 
     [Theory]
     [MemberData(nameof(TestData))]
-    public void Test_Write(uint value, byte[] expected)
+    public void Test_TryWrite(uint value, byte[] expected)
     {
         byte[] bytes = new byte[5];
 
-        int length = VarIntEncoding.Write(bytes, value);
+        bool success = VarIntEncoding.TryWrite(bytes, value, out int length);
+        Assert.True(success);
         Assert.Equal(expected, bytes.Take(length));
     }
 
     [Theory]
     [MemberData(nameof(TestData))]
-    public void Test_WriteWithPadding(uint value, byte[] expected)
+    public void Test_TryWriteInsufficientBufferLength(uint value, byte[] expected)
+    {
+        byte[] bytes = new byte[expected.Length - 1];
+
+        bool success = VarIntEncoding.TryWrite(bytes, value, out int length);
+        Assert.False(success);
+    }
+
+    [Theory]
+    [MemberData(nameof(TestData))]
+    public void Test_TryWriteWithPadding(uint value, byte[] expected)
     {
         // Test of the fast path where there are at least 8 bytes in the buffer
 
         byte[] bytes = new byte[sizeof(ulong)];
 
-        int length = VarIntEncoding.Write(bytes, value);
+        bool success = VarIntEncoding.TryWrite(bytes, value, out int length);
+        Assert.True(success);
         Assert.Equal(expected, bytes.Take(length));
     }
 }

--- a/Snappier/Internal/SnappyCompressor.cs
+++ b/Snappier/Internal/SnappyCompressor.cs
@@ -33,7 +33,7 @@ internal class SnappyCompressor : IDisposable
 
         if (!VarIntEncoding.TryWrite(output, (uint)input.Length, out bytesWritten))
         {
-            ThrowHelper.ThrowArgumentExceptionInsufficientOutputBuffer(nameof(output));
+            return false;
         }
         output = output.Slice(bytesWritten);
 

--- a/Snappier/Internal/SnappyCompressor.cs
+++ b/Snappier/Internal/SnappyCompressor.cs
@@ -31,7 +31,10 @@ internal class SnappyCompressor : IDisposable
 
         _workingMemory.EnsureCapacity(input.Length);
 
-        bytesWritten = VarIntEncoding.Write(output, (uint)input.Length);
+        if (!VarIntEncoding.TryWrite(output, (uint)input.Length, out bytesWritten))
+        {
+            ThrowHelper.ThrowArgumentExceptionInsufficientOutputBuffer(nameof(output));
+        }
         output = output.Slice(bytesWritten);
 
         while (input.Length > 0)
@@ -91,7 +94,10 @@ internal class SnappyCompressor : IDisposable
         _workingMemory.EnsureCapacity(input.Length);
 
         Span<byte> sizeBuffer = bufferWriter.GetSpan(VarIntEncoding.MaxLength);
-        int bytesWritten = VarIntEncoding.Write(sizeBuffer, (uint)input.Length);
+        if (!VarIntEncoding.TryWrite(sizeBuffer, (uint)input.Length, out int bytesWritten))
+        {
+            ThrowHelper.ThrowInvalidOperationException("IBufferWriter<byte> did not return a sufficient span for length prefix.");
+        }
         bufferWriter.Advance(bytesWritten);
 
         while (input.Length > 0)

--- a/Snappier/Internal/VarIntEncoding.Write.cs
+++ b/Snappier/Internal/VarIntEncoding.Write.cs
@@ -2,7 +2,7 @@
 
 internal static partial class VarIntEncoding
 {
-    private static int WriteSlow(Span<byte> output, uint length)
+    private static bool TryWriteSlow(Span<byte> output, uint length, out int bytesWritten)
     {
         const int b = 0b1000_0000;
 
@@ -10,39 +10,71 @@ internal static partial class VarIntEncoding
         {
             if (length < (1 << 7))
             {
+                if (output.Length < 1)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
                 output[0] = (byte) length;
-                return 1;
+                bytesWritten = 1;
             }
             else if (length < (1 << 14))
             {
+                if (output.Length < 2)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
                 output[0] = (byte) (length | b);
                 output[1] = (byte) (length >> 7);
-                return 2;
+                bytesWritten = 2;
             }
             else if (length < (1 << 21))
             {
+                if (output.Length < 3)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
                 output[0] = (byte) (length | b);
                 output[1] = (byte) ((length >> 7) | b);
                 output[2] = (byte) (length >> 14);
-                return 3;
+                bytesWritten = 3;
             }
             else if (length < (1 << 28))
             {
+                if (output.Length < 4)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
                 output[0] = (byte) (length | b);
                 output[1] = (byte) ((length >> 7) | b);
                 output[2] = (byte) ((length >> 14) | b);
                 output[3] = (byte) (length >> 21);
-                return 4;
+                bytesWritten = 4;
             }
             else
             {
+                if (output.Length < 5)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
                 output[0] = (byte) (length | b);
                 output[1] = (byte) ((length >> 7) | b);
                 output[2] = (byte) ((length >> 14) | b);
                 output[3] = (byte) ((length >> 21) | b);
                 output[4] = (byte) (length >> 28);
-                return 5;
+                bytesWritten = 5;
             }
         }
+
+        return true;
     }
 }

--- a/Snappier/Internal/VarIntEncoding.WriteFast.cs
+++ b/Snappier/Internal/VarIntEncoding.WriteFast.cs
@@ -24,8 +24,9 @@ internal static partial class VarIntEncoding
     /// </summary>
     /// <param name="buffer">Buffer to receive the value.</param>
     /// <param name="value">Value to encode.</param>
-    /// <returns>Number of bytes encoded.</returns>
-    public static int Write(Span<byte> buffer, uint value)
+    /// <param name="bytesWritten">Number of bytes written to the buffer.</param>
+    /// <returns><see langword="true"/> if the value was written successfully. <see langword="false"/> if the buffer is too small.</returns>
+    public static bool TryWrite(Span<byte> buffer, uint value, out int bytesWritten)
     {
         // Note: This method is likely to be inlined into the caller, potentially
         // eliding the size check if JIT knows the size of the buffer. BitConverter.IsLittleEndian
@@ -39,11 +40,12 @@ internal static partial class VarIntEncoding
             // up to 8 bytes are being copied to the buffer from a register. This guard prevents a
             // potential buffer overrun.
 
-            return WriteFast(ref MemoryMarshal.GetReference(buffer), value);
+            bytesWritten = WriteFast(ref MemoryMarshal.GetReference(buffer), value);
+            return true;
         }
 #endif
 
-        return WriteSlow(buffer, value);
+        return TryWriteSlow(buffer, value, out bytesWritten);
     }
 
 #if !NETSTANDARD2_0


### PR DESCRIPTION
Motivation
----------
Currently, if the consumer supplies an output buffer which is too short a useful `ArgumentException` is typically thrown. However, if it's so short that the varint-encoded length cannot be written, an `IndexOutOfRangeException` is thrown instead. This also means that the `TryCompress` variant incorrectly throws an exception rather than returning `false`.

Modifications
-------------
Redesign `VarIntEncoding.Write` to be `VarIntEncoding.TryWrite`, returning false if the length is insufficient. Use this return value to return `false` from the `TryCompress` variant. This results in `Compress` overloads throwing a more meaningful exception if `false` is received.