### PR TITLE
Remove dependency on System.Threading.Tasks.Extensions

### DIFF
--- a/Snappier/Internal/SnappyStreamCompressor.cs
+++ b/Snappier/Internal/SnappyStreamCompressor.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
-#if NETSTANDARD2_0
+#if !NET8_0_OR_GREATER
 using System.Runtime.InteropServices;
 #endif
 
@@ -62,7 +62,7 @@ internal class SnappyStreamCompressor : IDisposable
     /// <param name="stream">Output stream.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A block of memory with compressed data (if any). Must be used before any subsequent call to Write.</returns>
-    public async ValueTask WriteAsync(ReadOnlyMemory<byte> input, Stream stream, CancellationToken cancellationToken = default)
+    public async Task WriteAsync(ReadOnlyMemory<byte> input, Stream stream, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(stream);
         ObjectDisposedException.ThrowIf(_compressor is null, this);
@@ -96,7 +96,7 @@ internal class SnappyStreamCompressor : IDisposable
         WriteOutputBuffer(stream);
     }
 
-    public async ValueTask FlushAsync(Stream stream, CancellationToken cancellationToken = default)
+    public async Task FlushAsync(Stream stream, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(stream);
         ObjectDisposedException.ThrowIf(_compressor is null, this);
@@ -127,7 +127,7 @@ internal class SnappyStreamCompressor : IDisposable
         _outputBufferSize = 0;
     }
 
-    private async ValueTask WriteOutputBufferAsync(Stream stream, CancellationToken cancellationToken = default)
+    private async Task WriteOutputBufferAsync(Stream stream, CancellationToken cancellationToken = default)
     {
         Debug.Assert(_outputBuffer is not null);
 
@@ -136,10 +136,10 @@ internal class SnappyStreamCompressor : IDisposable
             return;
         }
 
-#if NETSTANDARD2_0
-        await stream.WriteAsync(_outputBuffer!, 0, _outputBufferSize, cancellationToken).ConfigureAwait(false);
-#else
+#if NET8_0_OR_GREATER
         await stream.WriteAsync(_outputBuffer.AsMemory(0, _outputBufferSize), cancellationToken).ConfigureAwait(false);
+#else
+        await stream.WriteAsync(_outputBuffer!, 0, _outputBufferSize, cancellationToken).ConfigureAwait(false);
 #endif
 
         _outputBufferSize = 0;

--- a/Snappier/Snappier.csproj
+++ b/Snappier/Snappier.csproj
@@ -59,7 +59,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Motivation
----------
We can safely operate on down-level .NET without this dependency using conditional compilation, and on modern .NET ValueTask is in-box.

Modifications
-------------
- Use Task instead of ValueTask for several internal methods in SnappyStreamCompressor. Since they don't return a result and they aren't using an IValueTaskSource there is no perf gain returning a ValueTask. If they complete synchronously they'll return the Task.CompletedTask singleton.
- Use conditional compilation in SnappyStream to change internals to use Task instead of ValueTask when targeting down-level runtimes.
- Drop the System.Threading.Tasks.Extensions dependency.

Relates to #140