### PR TITLE
Drop all NETSTANDARD2_0 conditionals

### DIFF
--- a/Snappier/Internal/CallerArgumentExpressionAttribute.cs
+++ b/Snappier/Internal/CallerArgumentExpressionAttribute.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if !NET8_0_OR_GREATER
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 

--- a/Snappier/Internal/CopyHelpers.cs
+++ b/Snappier/Internal/CopyHelpers.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
-#if !NETSTANDARD2_0
+#if NET8_0_OR_GREATER
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
@@ -12,7 +12,7 @@ namespace Snappier.Internal;
 
 internal class CopyHelpers
 {
-#if !NETSTANDARD2_0
+#if NET8_0_OR_GREATER
 
     // Raw bytes for PshufbFillPatterns. This syntax returns a ReadOnlySpan<byte> that references
     // directly to the static data within the DLL. This is only supported with bytes due to things
@@ -77,7 +77,7 @@ internal class CopyHelpers
 
         if (patternSize < 8)
         {
-#if !NETSTANDARD2_0
+#if NET8_0_OR_GREATER
             if (Ssse3.IsSupported) // SSSE3
             {
                 // Load the first eight bytes into an 128-bit XMM register, then use PSHUFB
@@ -127,15 +127,15 @@ internal class CopyHelpers
             else
             {
 #endif
-                // No SSSE3 Fallback
+            // No SSSE3 Fallback
 
-                // If plenty of buffer space remains, expand the pattern to at least 8
-                // bytes. The way the following loop is written, we need 8 bytes of buffer
-                // space if pattern_size >= 4, 11 bytes if pattern_size is 1 or 3, and 10
-                // bytes if pattern_size is 2.  Precisely encoding that is probably not
-                // worthwhile; instead, invoke the slow path if we cannot write 11 bytes
-                // (because 11 are required in the worst case).
-                if (!Unsafe.IsAddressGreaterThan(ref op, ref Unsafe.Subtract(ref bufferEnd, 11)))
+            // If plenty of buffer space remains, expand the pattern to at least 8
+            // bytes. The way the following loop is written, we need 8 bytes of buffer
+            // space if pattern_size >= 4, 11 bytes if pattern_size is 1 or 3, and 10
+            // bytes if pattern_size is 2.  Precisely encoding that is probably not
+            // worthwhile; instead, invoke the slow path if we cannot write 11 bytes
+            // (because 11 are required in the worst case).
+            if (!Unsafe.IsAddressGreaterThan(ref op, ref Unsafe.Subtract(ref bufferEnd, 11)))
                 {
                     while (patternSize < 8)
                     {
@@ -154,7 +154,7 @@ internal class CopyHelpers
                     IncrementalCopySlow(in source, ref op, ref opEnd);
                     return;
                 }
-#if !NETSTANDARD2_0
+#if NET8_0_OR_GREATER
             }
 #endif
         }

--- a/Snappier/Internal/Crc32CAlgorithm.cs
+++ b/Snappier/Internal/Crc32CAlgorithm.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 
-#if !NETSTANDARD2_0
+#if NET8_0_OR_GREATER
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
@@ -47,7 +47,7 @@ internal static class Crc32CAlgorithm
     {
         uint crcLocal = uint.MaxValue ^ crc;
 
-#if !NETSTANDARD2_0
+#if NET8_0_OR_GREATER
         // If available on the current CPU, use ARM CRC32C intrinsic operations.
         // The if Crc32 statements are optimized out by the JIT compiler based on CPU support.
         if (Crc32.IsSupported)

--- a/Snappier/Internal/HashTable.cs
+++ b/Snappier/Internal/HashTable.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
-#if !NETSTANDARD2_0
+#if NET8_0_OR_GREATER
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 #endif
@@ -100,7 +100,7 @@ internal class HashTable : IDisposable
 
         uint hash;
 
-#if !NETSTANDARD2_0
+#if NET8_0_OR_GREATER
         // We use mask as the second arg to the CRC function, as it's about to
         // be used anyway; it'd be equally correct to use 0 or some constant.
         // Mathematically, _mm_crc32_u32 (or similar) is a function of the

--- a/Snappier/Internal/Helpers.cs
+++ b/Snappier/Internal/Helpers.cs
@@ -1,7 +1,6 @@
 ﻿using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -14,17 +13,6 @@ namespace Snappier.Internal;
 
 internal static class Helpers
 {
-    // Variant of Debug.Fail that is marked with DoesNotReturn on all runtimes
-    [Conditional("DEBUG")]
-    [DoesNotReturn]
-    public static void Fail(string message)
-    {
-        Debug.Fail(message);
-
-        // Unreachable but prevents compiler errors
-        ThrowHelper.ThrowInvalidOperationException(message);
-    }
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int MaxCompressedLength(int sourceBytes)
     {

--- a/Snappier/Internal/IsExternalInit.cs
+++ b/Snappier/Internal/IsExternalInit.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if !NET8_0_OR_GREATER
 
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.

--- a/Snappier/Internal/NullableAttributes.cs
+++ b/Snappier/Internal/NullableAttributes.cs
@@ -1,5 +1,5 @@
 ﻿#define INTERNAL_NULLABLE_ATTRIBUTES
-#if NETSTANDARD2_0
+#if !NET8_0_OR_GREATER
 
 // https://github.com/dotnet/corefx/blob/48363ac826ccf66fbe31a5dcb1dc2aab9a7dd768/src/Common/src/CoreLib/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
 

--- a/Snappier/Internal/SnappyCompressor.cs
+++ b/Snappier/Internal/SnappyCompressor.cs
@@ -110,10 +110,10 @@ internal class SnappyCompressor : IDisposable
                 // Either this fragment is contiguous, or the first segment in the fragment is at least 32KB.
                 // In either case, compress the first (and possibly only) segment.
 
-#if NETSTANDARD2_0
-                ReadOnlySpan<byte> fragmentSpan = fragment.First.Span;
-#else
+#if NET8_0_OR_GREATER
                 ReadOnlySpan<byte> fragmentSpan = fragment.FirstSpan;
+#else
+                ReadOnlySpan<byte> fragmentSpan = fragment.First.Span;
 #endif
 
                 CompressFragment(fragmentSpan, bufferWriter);

--- a/Snappier/Internal/SnappyDecompressor.cs
+++ b/Snappier/Internal/SnappyDecompressor.cs
@@ -8,7 +8,7 @@ namespace Snappier.Internal;
 
 internal sealed class SnappyDecompressor : IDisposable
 {
-#if NETSTANDARD2_0
+#if !NET8_0_OR_GREATER
     private readonly byte[] _scratch = new byte[Constants.MaximumTagLength];
 
     private Span<byte> Scratch => _scratch.AsSpan();

--- a/Snappier/Internal/SnappyStreamDecompressor.cs
+++ b/Snappier/Internal/SnappyStreamDecompressor.cs
@@ -10,7 +10,7 @@ internal sealed class SnappyStreamDecompressor : IDisposable
 {
     private const int ScratchBufferSize = 4;
 
-#if NETSTANDARD2_0
+#if !NET8_0_OR_GREATER
     private readonly byte[] _scratch = new byte[ScratchBufferSize];
 #else
     [System.Runtime.CompilerServices.InlineArray(ScratchBufferSize)]

--- a/Snappier/Internal/ThrowHelper.cs
+++ b/Snappier/Internal/ThrowHelper.cs
@@ -35,7 +35,7 @@ internal static class ThrowHelper
     public static void ThrowNotSupportedException(string? message = null) =>
         throw new NotSupportedException(message);
 
-#if NETSTANDARD2_0
+#if !NET8_0_OR_GREATER
     [DoesNotReturn]
     private static void ThrowArgumentNullException(string? paramName) =>
         throw new ArgumentNullException(paramName);

--- a/Snappier/Internal/UnsafeReadonly.cs
+++ b/Snappier/Internal/UnsafeReadonly.cs
@@ -23,7 +23,7 @@ internal static class UnsafeReadonly
         public static ref readonly TTo As<TFrom, TTo>(ref readonly TFrom source) =>
             ref Unsafe.As<TFrom, TTo>(ref Unsafe.AsRef(in source));
 
-#if NETSTANDARD2_0
+#if !NET8_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nint ByteOffset<T>(ref readonly T origin, ref readonly T target) =>
             Unsafe.ByteOffset(ref Unsafe.AsRef(in origin), ref Unsafe.AsRef(in target));

--- a/Snappier/Internal/VarIntEncoding.Read.cs
+++ b/Snappier/Internal/VarIntEncoding.Read.cs
@@ -1,6 +1,6 @@
 ﻿using System.Buffers;
 
-#if !NETSTANDARD2_0
+#if NET8_0_OR_GREATER
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Numerics;
@@ -25,7 +25,7 @@ internal static partial class VarIntEncoding
 
     public static OperationStatus TryRead(ReadOnlySpan<byte> input, out uint result, out int bytesRead)
     {
-#if !NETSTANDARD2_0
+#if NET8_0_OR_GREATER
         if (Sse2.IsSupported && Bmi2.IsSupported && BitConverter.IsLittleEndian && input.Length >= Vector128<byte>.Count)
         {
             return ReadFast(input, out result, out bytesRead);
@@ -78,7 +78,7 @@ internal static partial class VarIntEncoding
         return OperationStatus.Done;
     }
 
-#if !NETSTANDARD2_0
+#if NET8_0_OR_GREATER
 
     private static ReadOnlySpan<uint> ReadMasks =>
     [

--- a/Snappier/Internal/VarIntEncoding.WriteFast.cs
+++ b/Snappier/Internal/VarIntEncoding.WriteFast.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET8_0_OR_GREATER
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -32,7 +32,7 @@ internal static partial class VarIntEncoding
         // eliding the size check if JIT knows the size of the buffer. BitConverter.IsLittleEndian
         // will always be elided based on CPU architecture.
 
-#if !NETSTANDARD2_0
+#if NET8_0_OR_GREATER
         if (BitConverter.IsLittleEndian && buffer.Length >= sizeof(ulong))
         {
             // Only use the fast path on little-endian CPUs and when there's enough padding in the
@@ -48,7 +48,7 @@ internal static partial class VarIntEncoding
         return TryWriteSlow(buffer, value, out bytesWritten);
     }
 
-#if !NETSTANDARD2_0
+#if NET8_0_OR_GREATER
 
     private static int WriteFast(ref byte buffer, uint value)
     {


### PR DESCRIPTION
Motivation
----------
These won't be correct if we add a NET4x target to the project, so simplify them to check for NET 8 or greater.

Modifications
-------------
Switch and invert all conditionals referencing NETSTANDARD2_0

Relates to #140 