### PR TITLE
Enable NRT warnings on down-level target frameworks

### DIFF
--- a/Snappier/Internal/CopyHelpers.cs
+++ b/Snappier/Internal/CopyHelpers.cs
@@ -63,11 +63,11 @@ internal class CopyHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void IncrementalCopy(ref readonly byte source, ref byte op, ref byte opEnd, ref byte bufferEnd)
     {
-        Debug.Assert(Unsafe.IsAddressLessThan(in source, in op));
-        Debug.Assert(!Unsafe.IsAddressGreaterThan(ref op, ref opEnd));
-        Debug.Assert(!Unsafe.IsAddressGreaterThan(ref opEnd, ref bufferEnd));
+        DebugExtensions.Assert(Unsafe.IsAddressLessThan(in source, in op));
+        DebugExtensions.Assert(!Unsafe.IsAddressGreaterThan(ref op, ref opEnd));
+        DebugExtensions.Assert(!Unsafe.IsAddressGreaterThan(ref opEnd, ref bufferEnd));
         // NOTE: The copy tags use 3 or 6 bits to store the copy length, so len <= 64.
-        Debug.Assert(Unsafe.ByteOffset(ref op, ref opEnd) <= (nint) 64);
+        DebugExtensions.Assert(Unsafe.ByteOffset(ref op, ref opEnd) <= (nint) 64);
         // NOTE: In practice the compressor always emits len >= 4, so it is ok to
         // assume that to optimize this function, but this is not guaranteed by the
         // compression format, so we have to also handle len < 4 in case the input
@@ -160,7 +160,7 @@ internal class CopyHelpers
         }
 
         // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-        Debug.Assert(patternSize >= 8);
+        DebugExtensions.Assert(patternSize >= 8);
 
         // Copy 2x 8 bytes at a time. Because op - src can be < 16, a single
         // UnalignedCopy128 might overwrite data in op. UnalignedCopy64 is safe

--- a/Snappier/Internal/DebugExtensions.cs
+++ b/Snappier/Internal/DebugExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Snappier.Internal;
+
+internal static class DebugExtensions
+{
+    // Variant of Debug.Assert that is marked with DoesNotReturnIf and CallerArgumentExpression on down-level runtimes
+    [Conditional("DEBUG")]
+    public static void Assert([DoesNotReturnIf(false)] bool condition,
+        [CallerArgumentExpression(nameof(condition))] string? message = null)
+    {
+#if NET8_0_OR_GREATER
+        Debug.Assert(condition, message);
+#else
+        if (!condition)
+        {
+            Debug.Fail(message);
+        }
+#endif
+    }
+
+#if !NET8_0_OR_GREATER
+
+    // Variant of Debug.Fail that is marked with DoesNotReturn on down-level runtimes
+    [Conditional("DEBUG")]
+    [DoesNotReturn]
+    private static void Fail(string message)
+    {
+        Debug.Fail(message);
+
+        // Unreachable but prevents compiler warnings, on down-level runtimes Debug.Fail is not marked as DoesNotReturn
+        ThrowHelper.ThrowInvalidOperationException(message);
+    }
+
+#endif
+}

--- a/Snappier/Internal/HashTable.cs
+++ b/Snappier/Internal/HashTable.cs
@@ -66,7 +66,7 @@ internal class HashTable : IDisposable
             return MinHashTableSize;
         }
 
-        Debug.Assert(inputSize > 1);
+        DebugExtensions.Assert(inputSize > 1);
         return 2 << Helpers.Log2Floor((uint)(inputSize - 1));
     }
 

--- a/Snappier/Internal/Helpers.cs
+++ b/Snappier/Internal/Helpers.cs
@@ -55,8 +55,8 @@ internal static class Helpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ClearAndReturn(byte[] array, int usedLength)
     {
-        Debug.Assert(array is not null);
-        Debug.Assert(usedLength >= 0);
+        DebugExtensions.Assert(array is not null);
+        DebugExtensions.Assert(usedLength >= 0);
 
         array.AsSpan(0, usedLength).Clear();
         ArrayPool<byte>.Shared.Return(array);
@@ -65,15 +65,15 @@ internal static class Helpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool LeftShiftOverflows(byte value, int shift)
     {
-        Debug.Assert(shift < 32);
+        DebugExtensions.Assert(shift < 32);
         return (value & ~(0xffff_ffffu >>> shift)) != 0;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static uint ExtractLowBytes(uint value, int numBytes)
     {
-        Debug.Assert(numBytes >= 0);
-        Debug.Assert(numBytes <= 4);
+        DebugExtensions.Assert(numBytes >= 0);
+        DebugExtensions.Assert(numBytes <= 4);
 
 #if NET8_0_OR_GREATER
         if (Bmi2.IsSupported)
@@ -183,7 +183,7 @@ internal static class Helpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int FindLsbSetNonZero(uint n)
     {
-        Debug.Assert(n != 0);
+        DebugExtensions.Assert(n != 0);
 
 #if NET8_0_OR_GREATER
         return BitOperations.TrailingZeroCount(n);
@@ -213,7 +213,7 @@ internal static class Helpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int FindLsbSetNonZero(ulong n)
     {
-        Debug.Assert(n != 0);
+        DebugExtensions.Assert(n != 0);
 
 #if NET8_0_OR_GREATER
         return BitOperations.TrailingZeroCount(n);

--- a/Snappier/Internal/SnappyCompressor.cs
+++ b/Snappier/Internal/SnappyCompressor.cs
@@ -153,7 +153,7 @@ internal class SnappyCompressor : IDisposable
 
     private void CompressFragment(ReadOnlySpan<byte> fragment, IBufferWriter<byte> bufferWriter)
     {
-        Debug.Assert(_workingMemory is not null);
+        DebugExtensions.Assert(_workingMemory is not null);
 
         Span<ushort> hashTable = _workingMemory.GetHashTable(fragment.Length);
 
@@ -175,8 +175,8 @@ internal class SnappyCompressor : IDisposable
     {
         unchecked
         {
-            Debug.Assert(input.Length <= Constants.BlockSize);
-            Debug.Assert((tableSpan.Length & (tableSpan.Length - 1)) == 0); // table must be power of two
+            DebugExtensions.Assert(input.Length <= Constants.BlockSize);
+            DebugExtensions.Assert((tableSpan.Length & (tableSpan.Length - 1)) == 0); // table must be power of two
 
             uint mask = (uint)(2 * (tableSpan.Length - 1));
 
@@ -235,11 +235,11 @@ internal class SnappyCompressor : IDisposable
                             // Manually unroll this loop into chunks of 4
 
                             uint dword = j == 0 ? preload : (uint) data;
-                            Debug.Assert(dword == Helpers.UnsafeReadUInt32(in Unsafe.Add(in ip, j)));
+                            DebugExtensions.Assert(dword == Helpers.UnsafeReadUInt32(in Unsafe.Add(in ip, j)));
                             ref ushort tableEntry = ref HashTable.TableEntry(ref table, dword, mask);
                             candidate = ref Unsafe.Add(in inputStart, tableEntry);
-                            Debug.Assert(!Unsafe.IsAddressLessThan(in candidate, in inputStart));
-                            Debug.Assert(Unsafe.IsAddressLessThan(in candidate, in Unsafe.Add(in ip, j)));
+                            DebugExtensions.Assert(!Unsafe.IsAddressLessThan(in candidate, in inputStart));
+                            DebugExtensions.Assert(Unsafe.IsAddressLessThan(in candidate, in Unsafe.Add(in ip, j)));
                             tableEntry = (ushort) (delta + j);
 
                             if (Helpers.UnsafeReadUInt32(in candidate) == dword)
@@ -253,11 +253,11 @@ internal class SnappyCompressor : IDisposable
 
                             int i1 = j + 1;
                             dword = (uint)(data >> 8);
-                            Debug.Assert(dword == Helpers.UnsafeReadUInt32(in Unsafe.Add(in ip, i1)));
+                            DebugExtensions.Assert(dword == Helpers.UnsafeReadUInt32(in Unsafe.Add(in ip, i1)));
                             tableEntry = ref HashTable.TableEntry(ref table, dword, mask);
                             candidate = ref Unsafe.Add(in inputStart, tableEntry);
-                            Debug.Assert(!Unsafe.IsAddressLessThan(in candidate, in inputStart));
-                            Debug.Assert(Unsafe.IsAddressLessThan(in candidate, in Unsafe.Add(in ip, i1)));
+                            DebugExtensions.Assert(!Unsafe.IsAddressLessThan(in candidate, in inputStart));
+                            DebugExtensions.Assert(Unsafe.IsAddressLessThan(in candidate, in Unsafe.Add(in ip, i1)));
                             tableEntry = (ushort) (delta + i1);
 
                             if (Helpers.UnsafeReadUInt32(in candidate) == dword)
@@ -271,11 +271,11 @@ internal class SnappyCompressor : IDisposable
 
                             int i2 = j + 2;
                             dword = (uint)(data >> 16);
-                            Debug.Assert(dword == Helpers.UnsafeReadUInt32(in Unsafe.Add(in ip, i2)));
+                            DebugExtensions.Assert(dword == Helpers.UnsafeReadUInt32(in Unsafe.Add(in ip, i2)));
                             tableEntry = ref HashTable.TableEntry(ref table, dword, mask);
                             candidate = ref Unsafe.Add(in inputStart, tableEntry);
-                            Debug.Assert(!Unsafe.IsAddressLessThan(in candidate, in inputStart));
-                            Debug.Assert(Unsafe.IsAddressLessThan(in candidate, in Unsafe.Add(in ip, i2)));
+                            DebugExtensions.Assert(!Unsafe.IsAddressLessThan(in candidate, in inputStart));
+                            DebugExtensions.Assert(Unsafe.IsAddressLessThan(in candidate, in Unsafe.Add(in ip, i2)));
                             tableEntry = (ushort) (delta + i2);
 
                             if (Helpers.UnsafeReadUInt32(in candidate) == dword)
@@ -289,11 +289,11 @@ internal class SnappyCompressor : IDisposable
 
                             int i3 = j + 3;
                             dword = (uint)(data >> 24);
-                            Debug.Assert(dword == Helpers.UnsafeReadUInt32(in Unsafe.Add(in ip, i3)));
+                            DebugExtensions.Assert(dword == Helpers.UnsafeReadUInt32(in Unsafe.Add(in ip, i3)));
                             tableEntry = ref HashTable.TableEntry(ref table, dword, mask);
                             candidate = ref Unsafe.Add(in inputStart, tableEntry);
-                            Debug.Assert(!Unsafe.IsAddressLessThan(in candidate, in inputStart));
-                            Debug.Assert(Unsafe.IsAddressLessThan(in candidate, in Unsafe.Add(in ip, i3)));
+                            DebugExtensions.Assert(!Unsafe.IsAddressLessThan(in candidate, in inputStart));
+                            DebugExtensions.Assert(Unsafe.IsAddressLessThan(in candidate, in Unsafe.Add(in ip, i3)));
                             tableEntry = (ushort) (delta + i3);
 
                             if (Helpers.UnsafeReadUInt32(in candidate) == dword)
@@ -314,7 +314,7 @@ internal class SnappyCompressor : IDisposable
 
                     while (true)
                     {
-                        Debug.Assert((uint) data == Helpers.UnsafeReadUInt32(in ip));
+                        DebugExtensions.Assert((uint) data == Helpers.UnsafeReadUInt32(in ip));
                         ref ushort tableEntry = ref HashTable.TableEntry(ref table, (uint) data, mask);
                         int bytesBetweenHashLookups = skip >> 5;
                         skip += bytesBetweenHashLookups;
@@ -327,8 +327,8 @@ internal class SnappyCompressor : IDisposable
                         }
 
                         candidate = ref Unsafe.Add(in inputStart, tableEntry);
-                        Debug.Assert(!Unsafe.IsAddressLessThan(in candidate, in inputStart));
-                        Debug.Assert(Unsafe.IsAddressLessThan(in candidate, in ip));
+                        DebugExtensions.Assert(!Unsafe.IsAddressLessThan(in candidate, in inputStart));
+                        DebugExtensions.Assert(Unsafe.IsAddressLessThan(in candidate, in ip));
 
                         tableEntry = (ushort)Unsafe.ByteOffset(in inputStart, in ip);
                         if ((uint) data == Helpers.UnsafeReadUInt32(in candidate))
@@ -343,7 +343,7 @@ internal class SnappyCompressor : IDisposable
                     // Step 2: A 4-byte match has been found.  We'll later see if more
                     // than 4 bytes match.  But, prior to the match, input
                     // bytes [next_emit, ip) are unmatched.  Emit them as "literal bytes."
-                    Debug.Assert(!Unsafe.IsAddressGreaterThan(in Unsafe.Add(in nextEmit, 16), in inputEnd));
+                    DebugExtensions.Assert(!Unsafe.IsAddressGreaterThan(in Unsafe.Add(in nextEmit, 16), in inputEnd));
                     op = ref EmitLiteralFast(ref op, in nextEmit, (uint)Unsafe.ByteOffset(in nextEmit, in ip));
 
                     // Step 3: Call EmitCopy, and then see if another EmitCopy could
@@ -384,7 +384,7 @@ internal class SnappyCompressor : IDisposable
                         }
 
                         // Expect 5 bytes to match
-                        Debug.Assert((data & 0xfffffffffful) ==
+                        DebugExtensions.Assert((data & 0xfffffffffful) ==
                                      (Helpers.UnsafeReadUInt64(in ip) & 0xfffffffffful));
 
                         // We are now looking for a 4-byte match again.  We read
@@ -417,7 +417,7 @@ internal class SnappyCompressor : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static ref byte EmitLiteralFast(ref byte op, ref readonly byte literal, uint length)
     {
-        Debug.Assert(length > 0);
+        DebugExtensions.Assert(length > 0);
 
         if (length <= 16)
         {
@@ -443,11 +443,11 @@ internal class SnappyCompressor : IDisposable
         }
         else
         {
-            Debug.Assert(n > 0);
+            DebugExtensions.Assert(n > 0);
             int count = (Helpers.Log2Floor(n) >> 3) + 1;
 
-            Debug.Assert(count >= 1);
-            Debug.Assert(count <= 4);
+            DebugExtensions.Assert(count >= 1);
+            DebugExtensions.Assert(count <= 4);
             op = unchecked((byte)(Constants.Literal | ((59 + count) << 2)));
             op = ref Unsafe.Add(ref op, 1);
 
@@ -466,10 +466,10 @@ internal class SnappyCompressor : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static ref byte EmitCopyAtMost64LenLessThan12(ref byte op, long offset, long length)
     {
-        Debug.Assert(length <= 64);
-        Debug.Assert(length >= 4);
-        Debug.Assert(offset < 65536);
-        Debug.Assert(length < 12);
+        DebugExtensions.Assert(length <= 64);
+        DebugExtensions.Assert(length >= 4);
+        DebugExtensions.Assert(offset < 65536);
+        DebugExtensions.Assert(length < 12);
 
         unchecked
         {
@@ -492,10 +492,10 @@ internal class SnappyCompressor : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static ref byte EmitCopyAtMost64LenGreaterThanOrEqualTo12(ref byte op, long offset, long length)
     {
-        Debug.Assert(length <= 64);
-        Debug.Assert(length >= 4);
-        Debug.Assert(offset < 65536);
-        Debug.Assert(length >= 12);
+        DebugExtensions.Assert(length <= 64);
+        DebugExtensions.Assert(length >= 4);
+        DebugExtensions.Assert(offset < 65536);
+        DebugExtensions.Assert(length >= 12);
 
         // Write 4 bytes, though we only care about 3 of them.  The output buffer
         // is required to have some slack, so the extra byte won't overrun it.
@@ -507,7 +507,7 @@ internal class SnappyCompressor : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static ref byte EmitCopyLenLessThan12(ref byte op, long offset, long length)
     {
-        Debug.Assert(length < 12);
+        DebugExtensions.Assert(length < 12);
 
         return ref EmitCopyAtMost64LenLessThan12(ref op, offset, length);
     }
@@ -515,7 +515,7 @@ internal class SnappyCompressor : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static ref byte EmitCopyLenGreaterThanOrEqualTo12(ref byte op, long offset, long length)
     {
-        Debug.Assert(length >= 12);
+        DebugExtensions.Assert(length >= 12);
 
         // A special case for len <= 64 might help, but so far measurements suggest
         // it's in the noise.
@@ -562,7 +562,7 @@ internal class SnappyCompressor : IDisposable
     internal static (int matchLength, bool matchLengthLessThan8) FindMatchLength(
         ref readonly byte s1, ref readonly byte s2, ref readonly byte s2Limit, ref ulong data)
     {
-        Debug.Assert(!Unsafe.IsAddressLessThan(in s2Limit, in s2));
+        DebugExtensions.Assert(!Unsafe.IsAddressLessThan(in s2Limit, in s2));
 
         if (BitConverter.IsLittleEndian && IntPtr.Size == 8)
         {
@@ -661,7 +661,7 @@ internal class SnappyCompressor : IDisposable
 
                 data = a2 >> (shift & (3 * 8));
                 matched += matchedBytes;
-                Debug.Assert(matched >= 8);
+                DebugExtensions.Assert(matched >= 8);
                 return ((int)matched, false);
             }
         }

--- a/Snappier/Internal/SnappyDecompressor.cs
+++ b/Snappier/Internal/SnappyDecompressor.cs
@@ -141,7 +141,7 @@ internal sealed class SnappyDecompressor : IDisposable
                     bytesConsumed = toCopy;
                     _scratchLength += toCopy;
 
-                    Debug.Assert(_scratchLength < scratch.Length);
+                    DebugExtensions.Assert(_scratchLength < scratch.Length);
                     break;
 
                 default:
@@ -185,7 +185,7 @@ internal sealed class SnappyDecompressor : IDisposable
     {
         // We only index into this array with a byte, and the list is 256 long, so it's safe to skip range checks.
         // JIT doesn't seem to recognize this currently, so we'll use a ref and Unsafe.Add to avoid the checks.
-        Debug.Assert(Constants.CharTable.Length >= 256);
+        DebugExtensions.Assert(Constants.CharTable.Length >= 256);
         ref readonly ushort charTable = ref MemoryMarshal.GetReference(Constants.CharTable);
 
         unchecked
@@ -265,7 +265,7 @@ internal sealed class SnappyDecompressor : IDisposable
 
                     if (TryFastAppend(ref op, ref bufferEnd, in input, Unsafe.ByteOffset(in input, in inputEnd), literalLength))
                     {
-                        Debug.Assert(literalLength < 61);
+                        DebugExtensions.Assert(literalLength < 61);
                         op = ref Unsafe.Add(ref op, literalLength);
                         input = ref Unsafe.Add(in input, literalLength);
                         // NOTE: There is no RefillTag here, as TryFastAppend()
@@ -427,7 +427,7 @@ internal sealed class SnappyDecompressor : IDisposable
     // DecompressAllTags will short circuit.
     private uint RefillTagFromScratch(ref readonly byte input, ref readonly byte inputEnd)
     {
-        Debug.Assert(_scratchLength > 0);
+        DebugExtensions.Assert(_scratchLength > 0);
 
         if (!Unsafe.IsAddressLessThan(in input, in inputEnd))
         {

--- a/Snappier/Internal/SnappyStreamCompressor.cs
+++ b/Snappier/Internal/SnappyStreamCompressor.cs
@@ -115,7 +115,7 @@ internal class SnappyStreamCompressor : IDisposable
 
     private void WriteOutputBuffer(Stream stream)
     {
-        Debug.Assert(_outputBuffer is not null);
+        DebugExtensions.Assert(_outputBuffer is not null);
 
         if (_outputBufferSize <= 0)
         {
@@ -129,7 +129,7 @@ internal class SnappyStreamCompressor : IDisposable
 
     private async Task WriteOutputBufferAsync(Stream stream, CancellationToken cancellationToken = default)
     {
-        Debug.Assert(_outputBuffer is not null);
+        DebugExtensions.Assert(_outputBuffer is not null);
 
         if (_outputBufferSize <= 0)
         {
@@ -139,7 +139,7 @@ internal class SnappyStreamCompressor : IDisposable
 #if NET8_0_OR_GREATER
         await stream.WriteAsync(_outputBuffer.AsMemory(0, _outputBufferSize), cancellationToken).ConfigureAwait(false);
 #else
-        await stream.WriteAsync(_outputBuffer!, 0, _outputBufferSize, cancellationToken).ConfigureAwait(false);
+        await stream.WriteAsync(_outputBuffer, 0, _outputBufferSize, cancellationToken).ConfigureAwait(false);
 #endif
 
         _outputBufferSize = 0;
@@ -165,7 +165,7 @@ internal class SnappyStreamCompressor : IDisposable
     /// <returns>Number of bytes consumed.</returns>
     private int CompressInput(ReadOnlySpan<byte> input)
     {
-        Debug.Assert(input.Length > 0);
+        DebugExtensions.Assert(input.Length > 0);
 
         if (_inputBufferSize == 0 && input.Length >= Constants.BlockSize)
         {
@@ -193,8 +193,8 @@ internal class SnappyStreamCompressor : IDisposable
 
     private void CompressBlock(ReadOnlySpan<byte> input)
     {
-        Debug.Assert(_compressor != null);
-        Debug.Assert(input.Length <= Constants.BlockSize);
+        DebugExtensions.Assert(_compressor != null);
+        DebugExtensions.Assert(input.Length <= Constants.BlockSize);
 
         const int headerSize = 8; // 1 byte for chunk type, 3 bytes for block size, 4 bytes for CRC
 

--- a/Snappier/Internal/SnappyStreamDecompressor.cs
+++ b/Snappier/Internal/SnappyStreamDecompressor.cs
@@ -37,7 +37,7 @@ internal sealed class SnappyStreamDecompressor : IDisposable
 
     public int Decompress(Span<byte> buffer)
     {
-        Debug.Assert(_decompressor != null);
+        DebugExtensions.Assert(_decompressor != null);
 
         ReadOnlySpan<byte> input = _input.Span;
 
@@ -259,7 +259,7 @@ internal sealed class SnappyStreamDecompressor : IDisposable
     /// </summary>
     private bool ReadChunkCrc(ref ReadOnlySpan<byte> input)
     {
-        Debug.Assert(_chunkBytesProcessed < 4);
+        DebugExtensions.Assert(_chunkBytesProcessed < 4);
 
         if (_chunkBytesProcessed == 0 && input.Length >= 4)
         {

--- a/Snappier/Internal/VarIntEncoding.Read.cs
+++ b/Snappier/Internal/VarIntEncoding.Read.cs
@@ -92,10 +92,10 @@ internal static partial class VarIntEncoding
 
     private static OperationStatus ReadFast(ReadOnlySpan<byte> input, out uint result, out int bytesRead)
     {
-        Debug.Assert(Sse2.IsSupported);
-        Debug.Assert(Bmi2.IsSupported);
-        Debug.Assert(input.Length >= Vector128<byte>.Count);
-        Debug.Assert(BitConverter.IsLittleEndian);
+        DebugExtensions.Assert(Sse2.IsSupported);
+        DebugExtensions.Assert(Bmi2.IsSupported);
+        DebugExtensions.Assert(input.Length >= Vector128<byte>.Count);
+        DebugExtensions.Assert(BitConverter.IsLittleEndian);
 
         int mask = ~Sse2.MoveMask(Vector128.LoadUnsafe(ref MemoryMarshal.GetReference(input)));
         bytesRead = BitOperations.TrailingZeroCount(mask) + 1;

--- a/Snappier/Snappier.csproj
+++ b/Snappier/Snappier.csproj
@@ -31,8 +31,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
-
-    <NoWarn Condition=" '$(TargetFramework)' == 'netstandard2.0' ">$(NoWarn);CS8602</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' == 'true' ">

--- a/Snappier/SnappyStream.cs
+++ b/Snappier/SnappyStream.cs
@@ -138,7 +138,7 @@ public sealed class SnappyStream : Stream
 
         if (_mode == CompressionMode.Compress && _wroteBytes)
         {
-            Debug.Assert(_compressor != null);
+            DebugExtensions.Assert(_compressor != null);
             _compressor.Flush(_stream);
         }
     }
@@ -156,7 +156,7 @@ public sealed class SnappyStream : Stream
 
         if (_mode == CompressionMode.Compress && _wroteBytes)
         {
-            Debug.Assert(_compressor != null);
+            DebugExtensions.Assert(_compressor != null);
             return _compressor.FlushAsync(_stream, cancellationToken);
         }
 
@@ -199,7 +199,7 @@ public sealed class SnappyStream : Stream
 
         int totalRead = 0;
 
-        Debug.Assert(_decompressor != null);
+        DebugExtensions.Assert(_decompressor != null);
         while (true)
         {
             int bytesRead = _decompressor.Decompress(buffer.Slice(totalRead));
@@ -210,7 +210,7 @@ public sealed class SnappyStream : Stream
                 break;
             }
 
-            Debug.Assert(_buffer != null);
+            DebugExtensions.Assert(_buffer != null);
 #if NET8_0_OR_GREATER
             int bytes = _stream.Read(_buffer);
 #else
@@ -265,7 +265,7 @@ public sealed class SnappyStream : Stream
         AsyncOperationStarting();
         try
         {
-            Debug.Assert(_decompressor != null);
+            DebugExtensions.Assert(_decompressor != null);
 
             // Finish decompressing any bytes in the input buffer
             int bytesRead = 0, bytesReadIteration = -1;
@@ -310,7 +310,7 @@ public sealed class SnappyStream : Stream
     {
         try
         {
-            Debug.Assert(_decompressor != null && _buffer != null);
+            DebugExtensions.Assert(_decompressor != null && _buffer != null);
             while (true)
             {
                 int bytesRead = await readTask.ConfigureAwait(false);
@@ -383,7 +383,7 @@ public sealed class SnappyStream : Stream
         EnsureCompressionMode();
         EnsureNotDisposed();
 
-        Debug.Assert(_compressor != null);
+        DebugExtensions.Assert(_compressor != null);
         _compressor.Write(buffer, _stream);
 
         _wroteBytes = true;
@@ -428,10 +428,10 @@ public sealed class SnappyStream : Stream
         AsyncOperationStarting();
         try
         {
-            Debug.Assert(_stream != null);
-            Debug.Assert(_compressor != null);
+            DebugExtensions.Assert(_stream != null);
+            DebugExtensions.Assert(_compressor != null);
 
-            await _compressor.WriteAsync(buffer, _stream!, cancellationToken).ConfigureAwait(false);
+            await _compressor.WriteAsync(buffer, _stream, cancellationToken).ConfigureAwait(false);
 
             _wroteBytes = true;
         }
@@ -450,7 +450,7 @@ public sealed class SnappyStream : Stream
             return;
         }
 
-        Debug.Assert(_compressor != null);
+        DebugExtensions.Assert(_compressor != null);
         // Make sure to only "flush" when we actually had some input
         if (_wroteBytes)
         {
@@ -470,7 +470,7 @@ public sealed class SnappyStream : Stream
             return default;
         }
 
-        Debug.Assert(_compressor != null);
+        DebugExtensions.Assert(_compressor != null);
         // Make sure to only "flush" when we actually had some input
         if (_wroteBytes)
         {
@@ -632,7 +632,7 @@ public sealed class SnappyStream : Stream
     private void AsyncOperationCompleting()
     {
         int oldValue = Interlocked.CompareExchange(ref _activeAsyncOperation, 0, 1);
-        Debug.Assert(oldValue == 1, $"Expected {nameof(_activeAsyncOperation)} to be 1, got {oldValue}");
+        DebugExtensions.Assert(oldValue == 1, $"Expected {nameof(_activeAsyncOperation)} to be 1, got {oldValue}");
     }
 
     // The helpers below aid with the various conditional compilation differences between legacy Task-based


### PR DESCRIPTION
Motivation
----------
Reduce the risk of coding errors by ensuring we're warning for possible null deference at compile time when targeting down-level runtimes.

Modifications
-------------
- Implement helper methods that have the correct nullable annotations for down-level runtimes
- Change all call sites to use these helpers
- Remove some null forgiving operators that are no longer necessary

Relates to #140