### PR TITLE
Add a .NET 4.7.2 target

### DIFF
--- a/Snappier/Snappier.csproj
+++ b/Snappier/Snappier.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;net8.0</TargetFrameworks>
 
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -54,8 +54,11 @@
     <None Include="..\images\icon.png" Pack="true" PackagePath="$(PackageIcon)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Memory" Version="4.6.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Motivation
----------
Reduce the dependency tree for .NET 4 users since a reference to System.Runtime.CompilerServices.Unsafe is not required for .NET 4, it's in-box.

Modifications
-------------
Add the target and adjust the package dependencies.

Closes #140